### PR TITLE
Document building on macOS versions prior to 10.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ For performance reasons, some functions might be written in C++, in `include/Ark
 * On macOS versions prior to 10.15, `libc++` lacks `filesystem` in the standard library.
 
   * Install a newer compiler using [Homebrew](https://docs.brew.sh/): `brew install gcc && brew link gcc`
-  * Pass compiler paths to `cmake` in the build step: `-DCMAKE_C_COMPILER=/usr/local/bin/gcc-9 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++-9`
+  * Pass compiler path to `cmake` in the build step: `-DCMAKE_CXX_COMPILER=/usr/local/bin/g++-9`
 
 Libs already included:
 * [rj format](https://github.com/ryjen/format), MIT licence

--- a/README.md
+++ b/README.md
@@ -154,8 +154,7 @@ Libs already included:
 # building Ark
 ~/Ark$ cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DARK_BUILD_EXE=1
 ~/Ark$ cmake --build build
-# installing Ark
-# works on Linux and on Windows (might need administrative privileges)
+# installing Ark (might need administrative privileges)
 ~/Ark$ cmake --install build --config Release
 # running
 ~/Ark$ Ark --help

--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ For performance reasons, some functions might be written in C++, in `include/Ark
 * C++17
 * CMake >= 3.12
 * Visual Studio >= 11 (on Windows)
+* On macOS versions prior to 10.15, `libc++` lacks `filesystem` in the standard library.
+
+  * Install a newer compiler using [Homebrew](https://docs.brew.sh/): `brew install gcc && brew link gcc`
+  * Pass compiler paths to `cmake` in the build step: `-DCMAKE_C_COMPILER=/usr/local/bin/gcc-9 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++-9`
 
 Libs already included:
 * [rj format](https://github.com/ryjen/format), MIT licence


### PR DESCRIPTION
This pull request adds a note about building on macOS versions prior to 10.15, which was solved in issue #87. I tried to keep it as short as possible, to not clutter the documentation.