### PR TITLE
Use only necessary files for installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ COPY --from=permissions-giver /out/docker-entrypoint.sh /out/docker/docker-entry
 FROM alpine:3.12 AS runner
 
 # Install cmake
-RUN apk --no-cache add cmake clang clang-dev make gcc g++ libc-dev linux-headers
+RUN apk --no-cache add cmake
 
 # Install Ark
 COPY --from=organizer /out/ark .

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,30 +20,41 @@ RUN git submodule update --init --recursive \
     && rm -rf `find . -type d -name ".git"` \
     && rm .gitmodules
 
-FROM alpine:3.12 AS organizer
-
-# Files for the build process
-WORKDIR /out/build
-COPY include include
-COPY lib lib
-COPY src src
-COPY thirdparty thirdparty
-COPY CMakeLists.txt .
-COPY --from=submodule-initializor /out /out/build
-
-# The docker-entrypoint.sh file
-COPY --from=permissions-giver /out/docker-entrypoint.sh /out/docker/docker-entrypoint.sh
-
 FROM alpine:3.12 AS builder
 
 # Install cmake
 RUN apk --no-cache add cmake clang clang-dev make gcc g++ libc-dev linux-headers
 
-# Build and install
-COPY --from=organizer /out/build .
+# Build
+COPY include include
+COPY lib lib
+COPY src src
+COPY thirdparty thirdparty
+COPY CMakeLists.txt .
+COPY --from=submodule-initializor /out .
 RUN cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DARK_BUILD_EXE=1 \
     && cmake --build build \
-    && cmake --install build --config Release
+    && rm -rf lib/ext
+
+FROM alpine:3.12 AS organizer
+
+# Files needed to run Ark
+WORKDIR /out/ark
+COPY --from=builder build build
+COPY --from=builder submodules submodules
+COPY --from=builder lib lib
+
+# The docker-entrypoint.sh file
+COPY --from=permissions-giver /out/docker-entrypoint.sh /out/docker/docker-entrypoint.sh
+
+FROM alpine:3.12 AS runner
+
+# Install cmake
+RUN apk --no-cache add cmake clang clang-dev make gcc g++ libc-dev linux-headers
+
+# Install Ark
+COPY --from=organizer /out/ark .
+RUN cmake --install build --config Release
 
 COPY --from=organizer /out/docker /usr/local/bin
 ENTRYPOINT [ "docker-entrypoint.sh" ]


### PR DESCRIPTION
Reduced 456MB to 449MB.

Inspired by the discussion from #148. Can we make it even smaller? What does `cmake --install build --config Release` actually do?