### PR TITLE
Fix error messages #159

### DIFF
--- a/src/Compiler/Lexer.cpp
+++ b/src/Compiler/Lexer.cpp
@@ -40,21 +40,6 @@ namespace Ark::internal
                             << "line: " << line << ", char: " << character << " - "
                             << "\n";
 
-            // position counter
-            if (current == '\n')
-            {
-                line++;
-                character = -1; // before first character
-
-                // close comments, don't append them
-                if (in_comment)
-                {
-                    in_comment = false;
-                    buffer.clear();
-                    continue;
-                }
-            }
-
             if (!in_string)
             {
                 // handle comments first
@@ -207,8 +192,25 @@ namespace Ark::internal
                 }
             }
 
-            // update position
-            character++;
+            // position counter
+            if (current == '\n')
+            {
+                line++;
+                character = 0; // before first character
+
+                // close comments, don't append them
+                if (in_comment)
+                {
+                    in_comment = false;
+                    buffer.clear();
+                    continue;
+                }
+            }
+            else 
+            {
+                // update position
+                character++;
+            }
         }
 
         // debugging information

--- a/src/Compiler/Lexer.cpp
+++ b/src/Compiler/Lexer.cpp
@@ -53,9 +53,9 @@ namespace Ark::internal
                     buffer.clear();
                     continue;
                 }
-				
-				if (!buffer.empty())
-					append_token_from_buffer();
+
+                if (!buffer.empty())
+                    append_token_from_buffer();
                 continue;
             }
 

--- a/src/Compiler/Lexer.cpp
+++ b/src/Compiler/Lexer.cpp
@@ -44,7 +44,7 @@ namespace Ark::internal
             if (current == '\n')
             {
                 line++;
-                character = 0;
+                character = -1; // before first character
 
                 // close comments, don't append them
                 if (in_comment)
@@ -53,10 +53,6 @@ namespace Ark::internal
                     buffer.clear();
                     continue;
                 }
-
-                if (!buffer.empty())
-                    append_token_from_buffer();
-                continue;
             }
 
             if (!in_string)
@@ -97,7 +93,7 @@ namespace Ark::internal
                     buffer = "#";
                 }
                 // separation
-                else if ((current == ' ' || current == '\t' || current == '\v'))
+                else if ((current == ' ' || current == '\t' || current == '\v' || current == '\n'))
                 {
                     if (!buffer.empty())
                         append_token_from_buffer();

--- a/src/Compiler/Lexer.cpp
+++ b/src/Compiler/Lexer.cpp
@@ -45,6 +45,7 @@ namespace Ark::internal
             {
                 line++;
                 character = 0;
+				continue;
 
                 // close comments, don't append them
                 if (in_comment)
@@ -119,7 +120,14 @@ namespace Ark::internal
                 }
                 // identifier, number, operator
                 else
+				{
+					if (buffer.empty())
+					{
+						saved_char = character;
+						saved_line = line;
+					}
                     buffer += current;
+				}
             }
             else  // we are in a string here
             {

--- a/src/Compiler/Lexer.cpp
+++ b/src/Compiler/Lexer.cpp
@@ -45,7 +45,7 @@ namespace Ark::internal
             {
                 line++;
                 character = 0;
-				continue;
+                continue;
 
                 // close comments, don't append them
                 if (in_comment)
@@ -120,14 +120,14 @@ namespace Ark::internal
                 }
                 // identifier, number, operator
                 else
-				{
-					if (buffer.empty())
-					{
-						saved_char = character;
-						saved_line = line;
-					}
+                {
+                    if (buffer.empty())
+                    {
+                        saved_char = character;
+                        saved_line = line;
+                    }
                     buffer += current;
-				}
+                }
             }
             else  // we are in a string here
             {

--- a/src/Compiler/Lexer.cpp
+++ b/src/Compiler/Lexer.cpp
@@ -45,7 +45,6 @@ namespace Ark::internal
             {
                 line++;
                 character = 0;
-                continue;
 
                 // close comments, don't append them
                 if (in_comment)
@@ -54,6 +53,10 @@ namespace Ark::internal
                     buffer.clear();
                     continue;
                 }
+				
+				if (!buffer.empty())
+					append_token_from_buffer();
+                continue;
             }
 
             if (!in_string)
@@ -94,7 +97,7 @@ namespace Ark::internal
                     buffer = "#";
                 }
                 // separation
-                else if ((current == ' ' || current == '\t' || current == '\v' || current == '\n'))
+                else if ((current == ' ' || current == '\t' || current == '\v'))
                 {
                     if (!buffer.empty())
                         append_token_from_buffer();


### PR DESCRIPTION
#159 Previously saved_line and saved_char were only set at the start of string literals. They should also be set at the start of identifiers, numbers and operators. 

Other issue is that the variable character is set to 0 when a newline character is reached but is incremented at the bottom of the loop, meaning that the first character of the line ends up being 1. Fixed by adding a continue to shortcircuit the loop.