### PR TITLE
Check for possible unbound variables at compile time

### DIFF
--- a/include/Ark/Compiler/Compiler.hpp
+++ b/include/Ark/Compiler/Compiler.hpp
@@ -69,6 +69,7 @@ namespace Ark
         uint16_t m_options;
         // tables: symbols, values, plugins and codes
         std::vector<std::string> m_symbols;
+        std::vector<std::string> m_defined_symbols;
         std::vector<internal::CValue> m_values;
         std::vector<std::vector<internal::Inst>> m_code_pages;
             // we need a temp code pages for some compilations passes
@@ -99,6 +100,9 @@ namespace Ark
         std::size_t addSymbol(const std::string& sym);
         std::size_t addValue(const internal::Node& x);
         std::size_t addValue(std::size_t page_id);
+
+        void addDefinedSymbol(const std::string &sym);
+        void checkForUndefinedSymbol();
 
         // push a number on stack (need 2 bytes)
         void pushNumber(uint16_t n, std::vector<internal::Inst>* page=nullptr);

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -84,11 +84,14 @@ namespace Ark
 
         // symbols table
         m_bytecode.push_back(Instruction::SYM_TABLE_START);
-            if (m_debug >= 1)
-                Ark::logger.info("Compiling");
-            // gather symbols, values, and start to create code segments
-            m_code_pages.emplace_back();  // create empty page
-            _compile(m_optimizer.ast(), 0);
+        
+        if (m_debug >= 1)
+            Ark::logger.info("Compiling");
+        // gather symbols, values, and start to create code segments
+        m_code_pages.emplace_back();  // create empty page
+        _compile(m_optimizer.ast(), 0);
+        checkForUndefinedSymbol();
+            
         if (m_debug >= 1)
             Ark::logger.info("Adding symbols table");
         // push size

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -291,6 +291,7 @@ namespace Ark
             {
                 std::string name = x.const_list()[1].string();
                 std::size_t i = addSymbol(name);
+                addDefinedSymbol(name);
 
                 // put value before symbol id
                 _compile(x.const_list()[2], p);
@@ -302,6 +303,7 @@ namespace Ark
             {
                 std::string name = x.const_list()[1].string();
                 std::size_t i = addSymbol(name);
+                addDefinedSymbol(name);
 
                 // put value before symbol id
                 _compile(x.const_list()[2], p);
@@ -335,6 +337,7 @@ namespace Ark
                     {
                         page(page_id).emplace_back(Instruction::MUT);
                         std::size_t var_id = addSymbol(it->string());
+                        addDefinedSymbol(it->string());
                         pushNumber(static_cast<uint16_t>(var_id), &(page(page_id)));
                     }
                 }
@@ -542,6 +545,31 @@ namespace Ark
             return m_values.size() - 1;
         }
         return static_cast<std::size_t>(std::distance(m_values.begin(), it));
+    }
+
+    void Compiler::addDefinedSymbol(const std::string &sym)
+    {
+        // otherwise, add the symbol, and return its id in the table
+        auto it = std::find(m_defined_symbols.begin(), m_defined_symbols.end(), sym);
+        if (it == m_defined_symbols.end())
+        {
+            if (m_debug >= 3)
+                Ark::logger.info("Registering declared symbol:", sym, "(", m_defined_symbols.size(), ")");
+
+            m_defined_symbols.push_back(sym);
+        }
+    }
+
+    void Compiler::checkForUndefinedSymbol()
+    {
+        for (const std::string &sym : m_symbols)
+        {
+            auto it = std::find(m_defined_symbols.begin(), m_defined_symbols.end(), sym);
+            if (it == m_defined_symbols.end())
+            {
+                throw Ark::CompilationError("unbound variable: " + sym + " (symbol is used but not defined)");
+            }
+        }
     }
 
     void Compiler::pushNumber(uint16_t n, std::vector<Inst>* page)


### PR DESCRIPTION
#144 Does a simple scan of all variables defined using Let, Mut or as function arguments, and checks for any symbols used that do not fall under those. This can help catch simple typos earlier. 

For source code (`a.ark`): 
```
(let b 10)
(print bb)
```
Output for `Ark a.ark -c` is:  
```
CompilationError: unbound variable: bb (symbol is used but not defined)
[ Error ] Ark::State.doFile(../a.ark) failed
```