### PR TITLE
Fix let/mut/set which could accepts more than 2 arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - error message when we're capturing an unbound variable
 - added `(sys:exit code)` as a builtin
 - bytecode integrity checking through a sha256 in the header
+- tests for `math:fibo` and `math:divs`
 
 ### Changed
 - the parser checks if set is given a dot expression (which is an error)
@@ -21,6 +22,7 @@
 - better handling of the code given to the REPL (adds new line)
 - renamed the executable from `Ark` to `ark`
 - now using Github Actions instead of Travis
+- the parser can now detect when let/mut/set are fed too many arguments, and generate an error
 
 ### Removed
 - class `Ark::internal::Inst` which was used as a wrapper between `uint8_t` and `Instruction`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - tests for `math:fibo` and `math:divs`
 
 ### Changed
-- the parser checks if set is given a dot expression (which is an error)
+- the parser checks if set is given a dot expression as an identifier (which is an error)
 - the parser should take in account captured variables as well, otherwise some variables are optimized while they are captured, resulting in runtime errors
 - better unbound variable error message
 - (implementation) every constructor with a single argument is now marked as explicit
@@ -23,6 +23,7 @@
 - renamed the executable from `Ark` to `ark`
 - now using Github Actions instead of Travis
 - the parser can now detect when let/mut/set are fed too many arguments, and generate an error
+- the compilater now handles `(set a b.c.d)`
 
 ### Removed
 - class `Ark::internal::Inst` which was used as a wrapper between `uint8_t` and `Instruction`

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -328,7 +328,13 @@ namespace Ark
                 std::size_t i = addSymbol(x.const_list()[1]);
 
                 // put value before symbol id
-                _compile(x.const_list()[2], p);
+                // trying to handle chained closure.field.field.field...
+                std::size_t pos = 2;
+                while (pos < x.const_list().size())
+                {
+                    _compile(x.const_list()[pos], p);
+                    pos++;
+                }
 
                 page(p).emplace_back(Instruction::STORE);
                 pushNumber(static_cast<uint16_t>(i), &page(p));

--- a/src/Compiler/Parser.cpp
+++ b/src/Compiler/Parser.cpp
@@ -212,7 +212,7 @@ namespace Ark
                         else
                             throwParseError("missing identifier to assign a value to, after keyword `set'", temp);
                         expect(!tokens.empty() && tokens.front().token != ")", "expected a value after the identifier", temp);
-                        // set can not accept a.b...c
+                        // set can not accept a.b...c as an identifier
                         if (tokens.front().type == TokenType::GetField)
                             throwParseError("found invalid token after keyword `set', expected an identifier, got a closure field reading expression", tokens.front());
                         // value

--- a/src/Compiler/Parser.cpp
+++ b/src/Compiler/Parser.cpp
@@ -195,6 +195,13 @@ namespace Ark
                         // value
                         while (tokens.front().token != ")")
                             block.push_back(parse(tokens, /* authorize_capture */ false, /* authorize_field_read */ true));
+
+                        // the block size can exceed 3 only if we have a serie of getfields
+                        expect(
+                            block.list().size() <= 3 || std::all_of(block.list().begin() + 3, block.list().end(), [](const Node& n) -> bool { return n.nodeType() == NodeType::GetField; }),
+                            "too many arguments given to keyword `" + token.token + "', got " + Utils::toString(block.list().size() - 1) + ", expected at most 3",
+                            m_last_token
+                        );
                     }
                     else if (token.token == "set")
                     {
@@ -211,6 +218,13 @@ namespace Ark
                         // value
                         while (tokens.front().token != ")")
                             block.push_back(parse(tokens, /* authorize_capture */ false, /* authorize_field_read */ true));
+
+                        // the block size can exceed 3 only if we have a serie of getfields
+                        expect(
+                            block.list().size() <= 3 || std::all_of(block.list().begin() + 3, block.list().end(), [](const Node& n) -> bool { return n.nodeType() == NodeType::GetField; }),
+                            "too many arguments given to keyword `" + token.token + "', got " + Utils::toString(block.list().size() - 1) + ", expected at most 3",
+                            m_last_token
+                        );
                     }
                     else if (token.token == "fun")
                     {


### PR DESCRIPTION
Now let/mut/set only accepts 2 arguments or a chain of one identifier + dot expressions (e.g. `(let a b.c.d)`)

Closes #197 