### PR TITLE
Fix the benchmarks link

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ LICENSE
 
 ## Performances
 
-See [https://github.com/ArkScript-lang/benchmarks](ArkScript-lang/benchmarks)
+See https://github.com/ArkScript-lang/benchmarks
 
 ## Games
 


### PR DESCRIPTION
Previous markdown translated to a relative path. In theory you could prepend a / but that doesn't work if the README is rendered on another site (via an aggregate site or something of the sort).

The simplest solution was just to remove the link syntax altogether as URI-like text is rendered as an anchor tag by default in most Markdown implementations (including Github's).