### PR TITLE
Update optimizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - the http module was updated to add `http:params:toList` and fix the `http:server:[method]` when passing a function
 - fixing the compiler when we encounter get fields in lists
 - updating the parser to support usually invalid constructions when they are in macros, to allow things like `!{defun (name args body) (let name (fun args body))}`
+- fixing the code optimizer to avoid removing unused variables which are defined on function calls
 
 ### Removed
 - `~UserType`, since we are doing manual memory management now

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -160,7 +160,7 @@ namespace Ark
             {
                 pushNumber(0x01);
                 m_bytecode.push_back(Instruction::HALT);
-                return;
+                break;
             }
             pushNumber(static_cast<uint16_t>(page.size() + 1));
 

--- a/src/Compiler/Optimizer.cpp
+++ b/src/Compiler/Optimizer.cpp
@@ -32,11 +32,12 @@ namespace Ark
         });
         count_occurences(m_ast);
 
-        // logic: remove piece of code with only 1 reference
+        // logic: remove piece of code with only 1 reference, if they aren't function calls
         run_on_global_scope_vars(m_ast, [this](Node& node, Node& parent, int idx){
             std::string name = node.const_list()[1].string();
             // a variable was only declared and never used
-            if (m_symAppearances.find(name) != m_symAppearances.end() && m_symAppearances[name] == 1)
+            if (m_symAppearances.find(name) != m_symAppearances.end() && m_symAppearances[name] == 1
+                && parent.list()[idx].list()[2].nodeType() != NodeType::List)
                 parent.list().erase(parent.list().begin() + idx);  // erase the node from the list
         });
     }


### PR DESCRIPTION
Kind of fixing it because it was just deleting things like `(let nice_variable (some_function argument foo bar))`, without letting the scripting call the function **if `nice_variable` wasn't used anywhere else**.