### PR TITLE
Fix 236

### DIFF
--- a/include/Ark/Compiler/Compiler.hpp
+++ b/include/Ark/Compiler/Compiler.hpp
@@ -32,6 +32,8 @@
 
 namespace Ark
 {
+    class State;
+
     /**
      * @brief The ArkScript bytecode compiler
      * 
@@ -75,6 +77,8 @@ namespace Ark
          * @return const bytecode_t& 
          */
         const bytecode_t& bytecode() noexcept;
+
+        friend class Ark::State;
 
     private:
         Parser m_parser;

--- a/include/Ark/VM/State.hpp
+++ b/include/Ark/VM/State.hpp
@@ -123,15 +123,12 @@ namespace Ark
         /**
          * @brief Reads and compiles code of file
          * 
-         * @param debug set the debug level
          * @param file the path of file code to compile 
-         * @param output set path of .arkc file 
-         * @param lib_dir the Lib Dir
-         * @param options set vm options
+         * @param output set path of .arkc file
          * @return true on success
          * @return false on failure and raise an exception
          */
-        bool compile(unsigned debug, const std::string& file, const std::string& output, const std::string& lib_dir, uint16_t options);
+        bool compile(const std::string& file, const std::string& output);
 
         inline void throwStateError(const std::string& message)
         {

--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -15,12 +15,7 @@ namespace Ark
     Compiler::Compiler(unsigned debug, const std::string& lib_dir, uint16_t options) :
         m_parser(debug, lib_dir, options), m_optimizer(options),
         m_options(options), m_debug(debug)
-    {
-        m_defined_symbols = {
-            "sys:args",
-            "sys:platform"
-        };
-    }
+    {}
 
     void Compiler::feed(const std::string& code, const std::string& filename)
     {

--- a/src/VM/State.cpp
+++ b/src/VM/State.cpp
@@ -85,6 +85,8 @@ namespace Ark
         try
         {
             compiler.feed(Utils::readFile(file), file);
+            for (auto& p : m_binded)
+                compiler.m_defined_symbols.push_back(p.first);
             compiler.compile();
 
             if (output != "")
@@ -161,6 +163,8 @@ namespace Ark
         try
         {
             compiler.feed(code);
+            for (auto& p : m_binded)
+                compiler.m_defined_symbols.push_back(p.first);
             compiler.compile();
         }
         catch (const std::exception& e)

--- a/src/VM/State.cpp
+++ b/src/VM/State.cpp
@@ -78,9 +78,9 @@ namespace Ark
         return result;
     }
 
-    bool State::compile(unsigned debug, const std::string& file, const std::string& output, const std::string& lib_dir, uint16_t options)
+    bool State::compile(const std::string& file, const std::string& output)
     {
-        Compiler compiler(debug, lib_dir, options);
+        Compiler compiler(m_debug_level, m_libdir, m_options);
 
         try
         {
@@ -136,18 +136,10 @@ namespace Ark
             std::filesystem::path directory =  (std::filesystem::path(file)).parent_path() / ARK_CACHE_DIRNAME;
             std::string path = (directory / filename).string();
 
-            bool compiled_successfuly = false;
+            if (!std::filesystem::exists(directory))  // create ark cache directory
+                std::filesystem::create_directory(directory);
 
-            if (Ark::Utils::fileExists(path))
-                compiled_successfuly = compile(m_debug_level, file, path, m_libdir, m_options);
-            else
-            {
-                if (!std::filesystem::exists(directory))  // create ark cache directory
-                    std::filesystem::create_directory(directory);
-
-                compiled_successfuly = compile(m_debug_level, file, path, m_libdir, m_options);
-            }
-
+            bool compiled_successfuly = compiled_successfuly = compile(file, path);
             if (compiled_successfuly && feed(path))
                 return true;
         }

--- a/src/VM/State.cpp
+++ b/src/VM/State.cpp
@@ -139,7 +139,7 @@ namespace Ark
             if (!std::filesystem::exists(directory))  // create ark cache directory
                 std::filesystem::create_directory(directory);
 
-            bool compiled_successfuly = compiled_successfuly = compile(file, path);
+            bool compiled_successfuly = compile(file, path);
             if (compiled_successfuly && feed(path))
                 return true;
         }


### PR DESCRIPTION
Closes #236 

Draft because it needs the updated compiler version to finish the update of the `Ark::State` (sort of messy as it is currently, duplicating code here and there for the compilation process).