### PR TITLE
Fixing macro processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 
 ### Changed
+- the macro processor can now handle multiple macro definitions in a if-macro: `!{if true { !{a 1} !{b 2} }}` is finally working
 
 ### Removed
 

--- a/src/Compiler/MacroProcessor.cpp
+++ b/src/Compiler/MacroProcessor.cpp
@@ -145,16 +145,29 @@ namespace Ark::internal
                 if (node.list()[i].nodeType() == NodeType::Macro)
                 {
                     // create a scope only if needed
-                    if ((!m_macros.empty() && !m_macros.back().empty()) || !has_created)
+                    if ((!m_macros.empty() && !m_macros.back().empty() && static_cast<unsigned>(m_macros.back()["#depth"].number()) < depth)
+                        || !has_created)
                     {
                         has_created = true;
                         m_macros.emplace_back();
                         m_macros.back()["#depth"] = Node(static_cast<double>(depth));
                     }
 
+                    bool had = hadBegin(node.list()[i]);
+                    bool removed_begin = false;
+                    std::size_t old = i;
+
                     registerMacro(node.list()[i]);
-                    if (node.list()[i].nodeType() == NodeType::Macro || node.list()[i].nodeType() == NodeType::Unused)
+                    if (hadBegin(node.list()[i]) && !had)
+                    {
+                        removeBegin(node, i);
+                        removed_begin = true;
+                    }
+                    else if (node.list()[i].nodeType() == NodeType::Macro || node.list()[i].nodeType() == NodeType::Unused)
                         node.list().erase(node.constList().begin() + i);
+
+                    if (removed_begin)
+                        i = old;
                 }
                 else  // running on non-macros
                 {

--- a/tests/arkscript/macro-tests.ark
+++ b/tests/arkscript/macro-tests.ark
@@ -61,6 +61,13 @@
         (set tests (assert-val true "macro if @" tests))
         (set tests (assert-val false "macro if @" tests))
     }
+    !{if true {
+        !{in_if_1 true}
+        !{in_if_2 true}
+    }}
+    (set tests (assert-val (and in_if_1 in_if_2) "macro if multiple definitions" tests))
+    !{undef in_if_1}
+    !{undef in_if_2}
 
     {
         !{val (+ 1 2 3)}


### PR DESCRIPTION
We couldn't define/use multiple macros in a if-macro:

```lisp
!{a 12}
!{if (= a 12) {
    !{b 13}
    !{c 14}
}}

(print a b c)
```

This was aborting the compilation because b and c weren't defined.