### PR TITLE
Replaced printf() with cout()

### DIFF
--- a/src/arkscript/REPL/Repl.cpp
+++ b/src/arkscript/REPL/Repl.cpp
@@ -92,7 +92,7 @@ namespace Ark
                     state.reset();
                 }
                 else
-                    std::printf("Ark::State::doString failed");
+                    std::cout << "Ark::State::doString failed\n";
             }
         }
 


### PR DESCRIPTION
This PR Closes #305

Here is a technical description of the main cause of the problem and the solution.

### Main Cause of the Issue

Here are the steps taken when an INCORRECT command is entered by the user

1. The method doString() is called as follows:
    `if (state.doString(tmp_code.str()))`
2. The incorrect command goes along with the methods until an EXCEPTION is called to throw an error as follows:
        `catch (const std::exception& e)
        {
            std::printf("%s\n", e.what());
            return false;
        }`
3. So, the body of if() statement is now neglected and the else part is executed as follows:
`std::printf("Ark::State::doString failed");`

### Solution

This causes the error message to be appended at the beginning of the next command output (whether it was a correct or incorrect command).

Replacing printf() with cout resolved the issue and now the error message is displayed after the exception has been thrown.