### PR TITLE
refactor(cmake): adding more warning flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,34 +16,38 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_COMPILER_IS_CLANG ON)
 endif()
 
-if (CMAKE_COMPILER_IS_GNUCXX)
-    set_property(GLOBAL PROPERTY ArkDebugFlags "${CMAKE_CXX_FLAGS_DEBUG} -pg -g -no-pie")
-    set_property(GLOBAL PROPERTY ArkReleaseFlags "-DNDEBUG -O3 -s")
-    set_property(GLOBAL PROPERTY ArkLinkerFlags "")
-elseif (MSVC)
-    set_property(GLOBAL PROPERTY ArkDebugFlags "/Z7 /DWIN32 /D_WINDOWS /W3 /GR /EHa /MDd")
-    set_property(GLOBAL PROPERTY ArkReleaseFlags "/DNDEBUG /DWIN32 /D_WINDOWS /W3 /GR /EHa /Ox /Ob2 /Oi /Ot /Oy /MD")
-    set_property(GLOBAL PROPERTY ArkLinkerFlags "")
-
-    add_compile_options(/wd4267)  # disable warning about data loss (size_t -> int)
-    add_compile_options(/wd4244)  # disable warning about data loss (size_t -> char)
-elseif (CMAKE_COMPILER_IS_CLANG)
-    set_property(GLOBAL PROPERTY ArkDebugFlags "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-    set_property(GLOBAL PROPERTY ArkReleaseFlags "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-    set_property(GLOBAL PROPERTY ArkLinkerFlags "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
-endif()
-
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # files needed for the library ArkReactor
 file(GLOB_RECURSE SOURCE_FILES
-    ${ark_SOURCE_DIR}/src/arkreactor/*.cpp
-)
+    ${ark_SOURCE_DIR}/src/arkreactor/*.cpp)
 
 add_library(ArkReactor
     SHARED
-    ${SOURCE_FILES}
-)
+    ${SOURCE_FILES})
+
+if (CMAKE_COMPILER_IS_GNUCXX)
+    target_compile_options(ArkReactor
+        PRIVATE -Wall
+        PRIVATE -Wextra)
+elseif (MSVC)
+    target_compile_options(ArkReactor
+        PRIVATE /W4
+        PRIVATE /MP4
+        PRIVATE /GR
+        PRIVATE /EHa
+        PRIVATE /wd4267   # disable warning about data loss (size_t -> int)
+        PRIVATE /wd4244   # disable warning about data loss (size_t -> char)
+        PRIVATE /wd4505)  # disable warning about unused static function was deleted
+elseif (CMAKE_COMPILER_IS_CLANG)
+    target_compile_options(ArkReactor
+        PRIVATE -Wall
+        PRIVATE -Wextra
+        PRIVATE -stdlib=libc++)
+    target_link_options(ArkReactor
+        PRIVATE -stdlib=libc++
+        PRIVATE -lc++abi)
+endif()
 
 
 # Adds utf8_decoder header project to includes.
@@ -76,16 +80,14 @@ endif()
 # including content of project
 target_include_directories(ArkReactor
     PUBLIC
-    ${ark_SOURCE_DIR}/include
-)
+    ${ark_SOURCE_DIR}/include)
 
 # setting up project properties
 set_target_properties(
     ArkReactor
     PROPERTIES
         CXX_STANDARD 17
-        CXX_STANDARD_REQUIRED ON
-)
+        CXX_STANDARD_REQUIRED ON)
 
 # Installs the dynamic library file.
 install(TARGETS ArkReactor
@@ -104,24 +106,6 @@ if(NOT ARK_NO_STD)
         PATTERN "std/.github" EXCLUDE)
 endif()
 
-
-# set debug compilation flags
-get_property(DebugFlags GLOBAL PROPERTY ArkDebugFlags)
-if (DebugFlags)
-    set(CMAKE_CXX_FLAGS_DEBUG "${DebugFlags}" CACHE STRING "Debug compilation options" FORCE)
-endif()
-
-# set release compilation flags
-get_property(ReleaseFlags GLOBAL PROPERTY ArkReleaseFlags)
-if (ReleaseFlags)
-    set(CMAKE_CXX_FLAGS_RELEASE "${ReleaseFlags}" CACHE STRING "Release compilation options" FORCE)
-endif()
-
-# set linker flags
-get_property(LinkerFlags GLOBAL PROPERTY ArkLinkerFlags)
-if (LinkerFlags)
-    set(CMAKE_EXE_LINKER_FLAGS "${LinkerFlags}" CACHE STRING "Linker options" FORCE)
-endif()
 
 # configuring Constants.hpp
 message(STATUS "ArkScript version ${ARK_VERSION_MAJOR}.${ARK_VERSION_MINOR}.${ARK_VERSION_PATCH}")
@@ -172,16 +156,14 @@ endif()
 
 configure_file(
     ${ark_SOURCE_DIR}/include/Ark/Constants.hpp.in
-    ${ark_SOURCE_DIR}/include/Ark/Constants.hpp
-)
+    ${ark_SOURCE_DIR}/include/Ark/Constants.hpp)
 
 if (ARK_BUILD_EXE)
     # additional files needed for the exe (repl, command line and stuff)
     set(EXE_SOURCES
         ${ark_SOURCE_DIR}/src/arkscript/REPL/Utils.cpp
         ${ark_SOURCE_DIR}/src/arkscript/REPL/Repl.cpp
-        ${ark_SOURCE_DIR}/src/arkscript/main.cpp
-    )
+        ${ark_SOURCE_DIR}/src/arkscript/main.cpp    )
 
     add_executable(arkscript ${EXE_SOURCES})
     add_executable(ark ${EXE_SOURCES})
@@ -210,15 +192,13 @@ if (ARK_BUILD_EXE)
         PROPERTIES
             CXX_STANDARD 17
             CXX_STANDARD_REQUIRED ON
-            CXX_EXTENSIONS OFF
-    )
+            CXX_EXTENSIONS OFF)
     set_target_properties(
         ark
         PROPERTIES
             CXX_STANDARD 17
             CXX_STANDARD_REQUIRED ON
-            CXX_EXTENSIONS OFF
-    )
+            CXX_EXTENSIONS OFF)
 
     target_link_libraries(arkscript PUBLIC ArkReactor)
     target_link_libraries(ark PUBLIC ArkReactor)


### PR DESCRIPTION
Refactoring the compiler flags to avoid leaking them to other projects depending on ArkReactor.

Some work need to be done on the modules to reflect the changes