### PR TITLE
Handled (Ctrl+D) key binding

### DIFF
--- a/src/arkscript/REPL/Repl.cpp
+++ b/src/arkscript/REPL/Repl.cpp
@@ -42,7 +42,13 @@ namespace Ark
                     str_lines = std::to_string(m_lines);
 
                 std::string prompt = "main:" + str_lines + "> ";
-                char const* buf = m_repl.input(prompt);
+                
+                char const* buf{ nullptr };
+                
+                do {
+                    buf = m_repl.input(prompt);
+                } while ( ( buf == nullptr ) && ( errno == EAGAIN ) );
+                
                 std::string line = (buf != nullptr) ? std::string(buf) : "";
 
                 // line history
@@ -50,8 +56,10 @@ namespace Ark
                 trim_whitespace(line);
 
                 // specific commands handling
-                if (line == "(quit)")
+                if (line == "(quit)" || buf == nullptr) {
+                    std::cout << "\nExiting REPL\n";
                     return 1;
+                }
 
                 if (!line.empty())
                     tmp_code << line << "\n";

--- a/src/arkscript/REPL/Repl.cpp
+++ b/src/arkscript/REPL/Repl.cpp
@@ -42,14 +42,11 @@ namespace Ark
                     str_lines = std::to_string(m_lines);
 
                 std::string prompt = "main:" + str_lines + "> ";
-                
                 char const* buf { nullptr };
-                
                 do
                 {
                     buf = m_repl.input(prompt);
                 } while ((buf == nullptr) && (errno == EAGAIN));
-                
                 std::string line = (buf != nullptr) ? std::string(buf) : "";
 
                 // line history

--- a/src/arkscript/REPL/Repl.cpp
+++ b/src/arkscript/REPL/Repl.cpp
@@ -43,11 +43,12 @@ namespace Ark
 
                 std::string prompt = "main:" + str_lines + "> ";
                 
-                char const* buf{ nullptr };
+                char const* buf { nullptr };
                 
-                do {
+                do
+                {
                     buf = m_repl.input(prompt);
-                } while ( ( buf == nullptr ) && ( errno == EAGAIN ) );
+                } while ((buf == nullptr) && (errno == EAGAIN));
                 
                 std::string line = (buf != nullptr) ? std::string(buf) : "";
 
@@ -56,7 +57,8 @@ namespace Ark
                 trim_whitespace(line);
 
                 // specific commands handling
-                if (line == "(quit)" || buf == nullptr) {
+                if (line == "(quit)" || buf == nullptr)
+                {
                     std::cout << "\nExiting REPL\n";
                     return 1;
                 }


### PR DESCRIPTION
This PR Closes #304 

### Technical Description for the Logical Error
The input() method presented in the line `char const* buf = m_repl.input(prompt);` can only return a **nullptr** in two specific cases:
1. Ctrl + C is pressed
2. Ctrl + D is pressed

We just need the REPL to exit when (CTRL + D) is pressed.
So, the only difference between the 2 key bindings would be the value assigned **errno**. As for (Ctrl + C) key binding, we would expect **errno** to be set to **EAGAIN**. Thus, checking for these two conditions assure that (Ctrl + D) was pressed and closes the REPL.

Side Note: I checked my logic against the implemented examples in **replxx** repository and the same approach has been followed to check for (Ctrl + D) and differentiate between its return value and that of (Ctrl + C) key binding.