### PR TITLE
Added extra checks for the parser

### DIFF
--- a/src/arkreactor/Compiler/Parser.cpp
+++ b/src/arkreactor/Compiler/Parser.cpp
@@ -134,7 +134,7 @@ namespace Ark
                  token.type == TokenType::Number ||
                  token.type == TokenType::String) &&
                 tokens.front().type == TokenType::Keyword)
-                throwParseError("Unexpected keyword `" + tokens.front().token + "' in the middle of an expression", token);
+                throwParseError("Unexpected keyword `" + tokens.front().token + "' in the middle of an expression", tokens.front());
 
             // loop until we reach the end of the block
             do
@@ -198,7 +198,7 @@ namespace Ark
         else if ((token.type == TokenType::Number ||
                   token.type == TokenType::String) &&
                  tokens.front().type == TokenType::Keyword)
-            throwParseError("Unexpected keyword `" + tokens.front().token + "' in the middle of an expression", token);
+            throwParseError("Unexpected keyword `" + tokens.front().token + "' in the middle of an expression", tokens.front());
         else if (token.type == TokenType::Keyword &&
                  !previous_token_was_lparen)
             throwParseError("Unexpected keyword `" + token.token + "' in the middle of an expression", token);

--- a/src/arkreactor/Compiler/Parser.cpp
+++ b/src/arkreactor/Compiler/Parser.cpp
@@ -104,7 +104,7 @@ namespace Ark
         using namespace std::string_literals;
 
         Token token = nextToken(tokens);
-        
+
         bool previous_token_was_lparen = false;
 
         // parse block
@@ -127,7 +127,7 @@ namespace Ark
             // return an empty block
             if (token.token == ")")
                 return block;
-            
+
             // check for unexpected keywords between expressions
             if ((token.type == TokenType::Operator ||
                  token.type == TokenType::Identifier ||


### PR DESCRIPTION
This PR Closes #276

This change is intended to check the tokens prior to Keywords to detect whether any is unexpected.

### Technical Description for the Problem

So, for keywords, a parsing algorithm is handled for each using the following methods:
```cpp
if (token.token == "if")
fun_ptr = &Parser::parseIf;

else if (token.token == "let" || token.token == "mut")
fun_ptr = &Parser::parseLetMut;

else if (token.token == "set")
fun_ptr = &Parser::parseSet;

else if (token.token == "fun")
fun_ptr = &Parser::parseFun;

else if (token.token == "while")
fun_ptr = &Parser::parseWhile;

else if (token.token == "begin")
fun_ptr = &Parser::parseBegin;

else if (token.token == "import")
fun_ptr = &Parser::parseImport;

else if (token.token == "quote")
fun_ptr = &Parser::parseQuote;

else if (token.token == "del")
fun_ptr = &Parser::parseDel;
```

While this is technically true, but the only thing lacking right here is that there are no checks for the tokens prior to the keywords. That's why when keywords were placed in the middle of an expression the parser couldn't detect the unexpected ones, because at that part of the code the parsing function for that specified keyword will not be called. Hence I added the following checks based on the ArkScript standard.

1. Keywords should only come after left parenthesis (That's how we force the parser to call the specific parsing function and check for errors, if present).
This point is introduced in the standard itself.
2. Any keyword that comes directly after an operator, a constant, or an identifier will raise an exception.

I applied some sanity checks including the ones you posted and some others from the ArkScript standard (placed some random keywords here and there to reproduce the error message) and everything seemed fine to me.