### PR TITLE
Fix compiler warnings:

### DIFF
--- a/src/arkreactor/Builtins/IO.cpp
+++ b/src/arkreactor/Builtins/IO.cpp
@@ -109,7 +109,7 @@ namespace Ark::internal::Builtins::IO
             if (n[1].valueType() != ValueType::String)
                 throw Ark::TypeError(IO_WRITE_TE1);
 
-            auto mode = n[1].string().c_str();
+            auto mode = n[1].string();
             if (mode != "w" && mode != "a")
                 throw std::runtime_error(IO_WRITE_VE_1);
 

--- a/src/arkreactor/VM/VM.cpp
+++ b/src/arkreactor/VM/VM.cpp
@@ -313,7 +313,7 @@ namespace Ark
                         val.setConst(true);
                         (*m_locals.back()).push_back(id, val);
 
-                        COZ_PROGRESS("ark vm let");
+                        COZ_PROGRESS_NAMED("ark vm let");
                         break;
                     }
 
@@ -492,7 +492,7 @@ namespace Ark
                         */
                         m_saved_scope = m_locals.back();
 
-                        COZ_PROGRESS("ark vm save_scope");
+                        COZ_PROGRESS_NAMED("ark vm save_scope");
                         break;
                     }
 
@@ -541,7 +541,7 @@ namespace Ark
 
                         loadPlugin(id);
 
-                        COZ_PROGRESS("ark vm plugin");
+                        COZ_PROGRESS_NAMED("ark vm plugin");
                         break;
                     }
 


### PR DESCRIPTION
    IO.cpp:     Broken code. Comparison will fail.
    VM.cpp:     Macro used incorrectly. Would have run but logging not to specific location.