### PR TITLE
Remove redundant version variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ include/Ark/Constants.hpp
 __arkscript__/
 *.arkc
 *.arkm
+/Installer.iss
 
 # Tests results
 tests/cpp/out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ set(ARK_VERSION_PATCH 1)
 # Uses GNU Install directory variables
 include(GNUInstallDirs)
 
+# configure installer.is
+configure_file("Installer.iss.in" "${CMAKE_SOURCE_DIR}/Installer.iss")
+
 # setting up compilations options
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/Installer.iss.in
+++ b/Installer.iss.in
@@ -1,6 +1,6 @@
 [Setup]
 AppName=ArkScript
-AppVersion=3.1.1
+AppVersion=@ARK_VERSION_MAJOR@.@ARK_VERSION_MINOR@.@ARK_VERSION_PATCH@
 AppPublisher=Alexandre Plateau
 AppPublisherURL=https://arkscript-lang.github.io
 DefaultDirName={autopf}\ArkScript


### PR DESCRIPTION
Fixes #330 

This method could go a little further, by replacing other variables.