### PR TITLE
Fix move semantics

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/ArkScript-lang/std.git
 [submodule "lib/modules"]
 	path = lib/modules
-	url = https://github.com/Loki-Astari/modules.git
+	url = https://github.com/ArkScript-lang/modules.git
 [submodule "lib/String"]
 	path = lib/String
 	url = https://github.com/ArkScript-lang/String.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/ArkScript-lang/std.git
 [submodule "lib/modules"]
 	path = lib/modules
-	url = https://github.com/ArkScript-lang/modules.git
+	url = https://github.com/Loki-Astari/modules.git
 [submodule "lib/String"]
 	path = lib/String
 	url = https://github.com/ArkScript-lang/String.git

--- a/include/Ark/Compiler/Macros/Executor.hpp
+++ b/include/Ark/Compiler/Macros/Executor.hpp
@@ -60,7 +60,7 @@ namespace Ark::internal
 
     protected:
         unsigned int m_debug;
-        MacroProcessor* m_macroprocessor;
+        MacroProcessor* m_macroprocessor;       // Note: None owned pointer.
 
         /**
          * @brief Find the nearest macro matching a giving name

--- a/include/Ark/Compiler/Macros/Executor.hpp
+++ b/include/Ark/Compiler/Macros/Executor.hpp
@@ -60,7 +60,7 @@ namespace Ark::internal
 
     protected:
         unsigned int m_debug;
-        MacroProcessor* m_macroprocessor;  // Note: None owned pointer.
+        MacroProcessor* m_macroprocessor;  // Note: Non owned pointer.
 
         /**
          * @brief Find the nearest macro matching a giving name

--- a/include/Ark/Compiler/Macros/Executor.hpp
+++ b/include/Ark/Compiler/Macros/Executor.hpp
@@ -60,7 +60,7 @@ namespace Ark::internal
 
     protected:
         unsigned int m_debug;
-        MacroProcessor* m_macroprocessor;       // Note: None owned pointer.
+        MacroProcessor* m_macroprocessor;  // Note: None owned pointer.
 
         /**
          * @brief Find the nearest macro matching a giving name

--- a/include/Ark/VM/Plugin.hpp
+++ b/include/Ark/VM/Plugin.hpp
@@ -44,6 +44,13 @@ namespace Ark::internal
         SharedLibrary();
 
         /**
+         * @brief Disable copy semantics as this contains a pointer.
+         * 
+         */
+        SharedLibrary(const SharedLibrary&) = delete;
+        SharedLibrary& operator=(const SharedLibrary&) = delete;
+
+        /**
          * @brief Construct a new Shared Library object
          * 
          * @param path path to the shared library

--- a/include/Ark/VM/Scope.hpp
+++ b/include/Ark/VM/Scope.hpp
@@ -72,7 +72,7 @@ namespace Ark::internal
          * @param val 
          * @return uint16_t 
          */
-        uint16_t idFromValue(Value&& val) noexcept;
+        uint16_t idFromValue(const Value& val) const noexcept;
 
         /**
          * @brief Return the size of the scope

--- a/include/Ark/VM/UserType.hpp
+++ b/include/Ark/VM/UserType.hpp
@@ -68,7 +68,9 @@ namespace Ark
         template <typename T>
         explicit UserType(T* data = nullptr, ControlFuncs* block = nullptr) noexcept :
             m_type_id(internal::type_uid<T>::value),
-            m_data(reinterpret_cast<void*>(data), [block](void *data){ if (block && block->deleter){block->deleter(data);}}),
+            m_data(reinterpret_cast<void*>(data), [block](void* data) {
+                if (block && block->deleter) { block->deleter(data); }
+            }),
             m_funcs(block)
         {}
 
@@ -135,8 +137,8 @@ namespace Ark
 
     private:
         uint16_t m_type_id;
-        std::shared_ptr<void>  m_data;
-        ControlFuncs* m_funcs;          // Not none owned pointer.
+        std::shared_ptr<void> m_data;
+        ControlFuncs* m_funcs;  // Not none owned pointer.
     };
 
 }

--- a/include/Ark/VM/UserType.hpp
+++ b/include/Ark/VM/UserType.hpp
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <vector>
 #include <utility>
+#include <memory>
 
 #include <Ark/Platform.hpp>
 
@@ -65,32 +66,28 @@ namespace Ark
          * @param data a pointer to the data to store in the object
          */
         template <typename T>
-        explicit UserType(T* data = nullptr) noexcept :
+        explicit UserType(T* data = nullptr, ControlFuncs* block = nullptr) noexcept :
             m_type_id(internal::type_uid<T>::value),
-            m_data(static_cast<void*>(data)),
-            m_funcs(nullptr)
+            m_data(reinterpret_cast<void*>(data), [block](void *data){ if (block && block->deleter){block->deleter(data);}}),
+            m_funcs(block)
         {}
-
-        /**
-         * @brief Destroy the User Type object
-         * @details Called by the VM when `(del obj)` is found or when the object goes
-         *          out of scope.
-         */
-        void del();
 
         /**
          * @brief Set the control functions structure
          * 
          * @param block A pointer to an instance of this block
          */
-        inline void setControlFuncs(ControlFuncs* block) noexcept;
+        // inline void setControlFuncs(ControlFuncs* block) noexcept;
 
         /**
          * @brief Get the pointer to the object
          * 
          * @return void* 
          */
-        inline void* data() const noexcept;
+        void* data() const noexcept
+        {
+            return m_data.get();
+        }
 
         /**
          * @brief Check if the object held is of a given type
@@ -123,13 +120,13 @@ namespace Ark
         template <typename T>
         T& as() noexcept
         {
-            return *static_cast<T*>(m_data);
+            return *reinterpret_cast<T*>(m_data.get());
         }
 
         template <typename T>
         const T& as() const noexcept
         {
-            return *static_cast<T*>(m_data);
+            return *reinterpret_cast<T*>(m_data.get());
         }
 
         friend ARK_API bool operator==(const UserType& A, const UserType& B) noexcept;
@@ -138,11 +135,10 @@ namespace Ark
 
     private:
         uint16_t m_type_id;
-        void* m_data;
-        ControlFuncs* m_funcs;
+        std::shared_ptr<void>  m_data;
+        ControlFuncs* m_funcs;          // Not none owned pointer.
     };
 
-#include "inline/UserType.inl"
 }
 
 #endif

--- a/include/Ark/VM/UserType.hpp
+++ b/include/Ark/VM/UserType.hpp
@@ -75,13 +75,6 @@ namespace Ark
         {}
 
         /**
-         * @brief Set the control functions structure
-         * 
-         * @param block A pointer to an instance of this block
-         */
-        // inline void setControlFuncs(ControlFuncs* block) noexcept;
-
-        /**
          * @brief Get the pointer to the object
          * 
          * @return void* 

--- a/include/Ark/VM/VM.hpp
+++ b/include/Ark/VM/VM.hpp
@@ -119,7 +119,9 @@ namespace Ark
         friend class Repl;
 
     private:
-        State* m_state;
+        State* m_state;     // Note: This is a non owned pointer.
+                            //       This should probably be changed to be a reference to
+                            //       show that the object does not take ownership.
 
         int m_exit_code;   ///< VM exit code, defaults to 0. Can be changed through `sys:exit`
         int m_ip;          ///< instruction pointer
@@ -142,6 +144,7 @@ namespace Ark
         Value m_no_value = internal::Builtins::nil;
 
         void* m_user_pointer;  ///< needed to pass data around when binding ArkScript in a program
+                               // Note: This is a non owned pointer.
 
         /**
          * @brief Run ArkScript bytecode inside a try catch to retrieve all the exceptions and display a stack trace if needed

--- a/include/Ark/VM/VM.hpp
+++ b/include/Ark/VM/VM.hpp
@@ -119,6 +119,7 @@ namespace Ark
         friend class Repl;
 
     private:
+        // TODO
         State* m_state;  // Note: This is a non owned pointer.
                          //       This should probably be changed to be a reference to
                          //       show that the object does not take ownership.

--- a/include/Ark/VM/VM.hpp
+++ b/include/Ark/VM/VM.hpp
@@ -119,9 +119,9 @@ namespace Ark
         friend class Repl;
 
     private:
-        State* m_state;     // Note: This is a non owned pointer.
-                            //       This should probably be changed to be a reference to
-                            //       show that the object does not take ownership.
+        State* m_state;  // Note: This is a non owned pointer.
+                         //       This should probably be changed to be a reference to
+                         //       show that the object does not take ownership.
 
         int m_exit_code;   ///< VM exit code, defaults to 0. Can be changed through `sys:exit`
         int m_ip;          ///< instruction pointer

--- a/include/Ark/VM/VM.hpp
+++ b/include/Ark/VM/VM.hpp
@@ -256,7 +256,7 @@ namespace Ark
          * @param value the value to search for
          * @return uint16_t 
          */
-        uint16_t findNearestVariableIdWithValue(Value&& value) noexcept;
+        uint16_t findNearestVariableIdWithValue(const Value& value) const noexcept;
 
         /**
          * @brief Throw a VM error message

--- a/include/Ark/VM/Value.hpp
+++ b/include/Ark/VM/Value.hpp
@@ -110,7 +110,7 @@ namespace Ark
         template <typename T>
         Value(ValueType type, T&& value) noexcept :
             m_const_type(static_cast<uint8_t>(type)),
-            m_value(value)
+            m_value(std::move(value))
         {}
 
 #ifdef ARK_PROFILER_COUNT

--- a/include/Ark/VM/inline/UserType.inl
+++ b/include/Ark/VM/inline/UserType.inl
@@ -1,9 +1,0 @@
-inline void UserType::setControlFuncs(ControlFuncs* block) noexcept
-{
-    m_funcs = block;
-}
-
-inline void* UserType::data() const noexcept
-{
-    return m_data;
-}

--- a/include/Ark/VM/inline/VM.inl
+++ b/include/Ark/VM/inline/VM.inl
@@ -30,7 +30,7 @@ Value VM::call(const std::string& name, Args&&... args)
         throwVMError("unbound variable: " + name);
 
     // convert and push arguments in reverse order
-    std::vector<Value> fnargs { { Value(args)... } };
+    std::vector<Value> fnargs { { Value(std::forward<Args>(args))... } };
     for (auto it2 = fnargs.rbegin(), it_end = fnargs.rend(); it2 != it_end; ++it2)
         push(*it2);
 
@@ -83,7 +83,7 @@ Value VM::resolve(const Value* val, Args&&... args)
     std::size_t pp = m_pp;
 
     // convert and push arguments in reverse order
-    std::vector<Value> fnargs { { Value(args)... } };
+    std::vector<Value> fnargs { { Value(std::forward<Args>(args))... } };
     for (auto it = fnargs.rbegin(), it_end = fnargs.rend(); it != it_end; ++it)
         push(resolveRef(it));
     // push function

--- a/src/arkreactor/Compiler/AST/Parser.cpp
+++ b/src/arkreactor/Compiler/AST/Parser.cpp
@@ -518,13 +518,13 @@ namespace Ark::internal
 
                     Parser p(m_debug, m_options, m_libenv);
                     // feed the new parser with our parent includes
-                    for (auto&& pi : m_parent_include)
+                    for (auto const& pi : m_parent_include)
                         p.m_parent_include.push_back(pi);  // new parser, we can assume that the parent include list is empty
                     p.m_parent_include.push_back(m_file);  // add the current file to avoid importing it again
                     p.feed(Utils::readFile(included_file), included_file);
 
                     // update our list of included files
-                    for (auto&& inc : p.m_parent_include)
+                    for (auto const& inc : p.m_parent_include)
                     {
                         if (std::find(m_parent_include.begin(), m_parent_include.end(), inc) == m_parent_include.end())
                             m_parent_include.push_back(inc);
@@ -570,7 +570,7 @@ namespace Ark::internal
             return path;
 
         // search in all folders in environment path
-        for (auto&& p : m_libenv)
+        for (auto const& p : m_libenv)
         {
             // then search in the standard library directory
             if (std::string f = p + "/std/" + file; Utils::fileExists(f))

--- a/src/arkreactor/Compiler/Compiler.cpp
+++ b/src/arkreactor/Compiler/Compiler.cpp
@@ -548,7 +548,7 @@ namespace Ark
             for (auto exp = x.constList().begin() + n, exp_end = x.constList().end(); exp != exp_end; ++exp)
                 _compile(*exp, p);
             // push proc from temp page
-            for (auto&& inst : m_temp_pages.back())
+            for (auto const& inst : m_temp_pages.back())
                 page(p).push_back(inst);
             m_temp_pages.pop_back();
 

--- a/src/arkreactor/VM/Scope.cpp
+++ b/src/arkreactor/VM/Scope.cpp
@@ -33,7 +33,7 @@ namespace Ark::internal
         return nullptr;
     }
 
-    uint16_t Scope::idFromValue(Value&& val) noexcept
+    uint16_t Scope::idFromValue(const Value& val) const noexcept
     {
         for (std::size_t i = 0, end = m_data.size(); i < end; ++i)
         {

--- a/src/arkreactor/VM/UserType.cpp
+++ b/src/arkreactor/VM/UserType.cpp
@@ -2,13 +2,6 @@
 
 namespace Ark
 {
-    void UserType::del()
-    {
-        // call a custom deleter on the data held by the usertype
-        if (m_funcs != nullptr && m_funcs->deleter != nullptr)
-            m_funcs->deleter(m_data);
-    }
-
     bool operator==(const UserType& A, const UserType& B) noexcept
     {
         return (A.m_type_id == B.m_type_id) && (A.m_data == B.m_data);

--- a/src/arkreactor/VM/VM.cpp
+++ b/src/arkreactor/VM/VM.cpp
@@ -88,7 +88,7 @@ namespace Ark
             path = (fs::path(m_state->m_filename).parent_path() / fs::path(file)).relative_path().string();
 
         std::shared_ptr<SharedLibrary> lib;
-        for (auto&& v : m_state->m_libenv)
+        for (auto const& v : m_state->m_libenv)
         {
             std::string lib_path = (fs::path(v) / fs::path(file)).string();
 
@@ -1103,11 +1103,11 @@ namespace Ark
     //             error handling
     // ------------------------------------------
 
-    uint16_t VM::findNearestVariableIdWithValue(Value&& value) noexcept
+    uint16_t VM::findNearestVariableIdWithValue(const Value& value) const noexcept
     {
         for (auto it = m_locals.rbegin(), it_end = m_locals.rend(); it != it_end; ++it)
         {
-            if (auto id = (*it)->idFromValue(std::move(value)); id < m_state->m_symbols.size())
+            if (auto id = (*it)->idFromValue(value); id < m_state->m_symbols.size())
                 return id;
         }
         return static_cast<uint16_t>(~0);

--- a/src/arkreactor/VM/VM.cpp
+++ b/src/arkreactor/VM/VM.cpp
@@ -471,9 +471,6 @@ namespace Ark
 
                         if (Value* var = findNearestVariable(id); var != nullptr)
                         {
-                            // free usertypes
-                            if (var->valueType() == ValueType::User)
-                                var->usertypeRef().del();
                             *var = Value();
                             break;
                         }
@@ -1180,8 +1177,7 @@ namespace Ark
                 Value* tmp = pop();
                 if (tmp->valueType() == ValueType::InstPtr)
                     --m_fc;
-                else if (tmp->valueType() == ValueType::User)
-                    tmp->usertypeRef().del();
+                *tmp = m_no_value;
             }
             // pop the PP as well
             pop();

--- a/src/arkreactor/VM/Value.cpp
+++ b/src/arkreactor/VM/Value.cpp
@@ -92,15 +92,15 @@ namespace Ark
     {}
 
     Value::Value(std::vector<Value>&& value) noexcept :
-        m_const_type(init_const_type(false, ValueType::List)), m_value(value)
+        m_const_type(init_const_type(false, ValueType::List)), m_value(std::move(value))
     {}
 
     Value::Value(internal::Closure&& value) noexcept :
-        m_const_type(init_const_type(false, ValueType::Closure)), m_value(value)
+        m_const_type(init_const_type(false, ValueType::Closure)), m_value(std::move(value))
     {}
 
     Value::Value(UserType&& value) noexcept :
-        m_const_type(init_const_type(false, ValueType::User)), m_value(value)
+        m_const_type(init_const_type(false, ValueType::User)), m_value(std::move(value))
     {}
 
     Value::Value(Value* ref) noexcept :
@@ -143,7 +143,7 @@ namespace Ark
 
     void Value::push_back(Value&& value)
     {
-        list().push_back(value);
+        list().push_back(std::move(value));
     }
 
     // --------------------------

--- a/tests/cpp/03.cpp
+++ b/tests/cpp/03.cpp
@@ -39,11 +39,9 @@ int main()
     state.loadFunction("getBreakfast", [](std::vector<Ark::Value>& n [[maybe_unused]], Ark::VM* vm [[maybe_unused]]) -> Ark::Value {
         // we need to send the address of the object, which will be casted
         // to void* internally
-        Ark::Value v = Ark::Value(Ark::UserType(&getBreakfast()));
-
         // register the unique control functions block for this usertype
         // this cfs block can be shared between multiple usertype to reduce memory usage
-        v.usertypeRef().setControlFuncs(get_cfs());
+        Ark::Value v = Ark::Value(Ark::UserType(&getBreakfast(), get_cfs()));
 
         return v;
     });


### PR DESCRIPTION
Fixed a potential bug with `UserType` where user supplied data could be deleted in one object when it is still potentially being used by another object (because the original object was copied).

Fixed a couple of other issues with move semantics (to make it work correclty)