### PR TITLE
Change clipp program name

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,15 +173,15 @@ DESCRIPTION
         ArkScript programming language
 
 SYNOPSIS
-        ark -h
-        ark -v
-        ark --dev-info
-        ark -e <expression>
-        ark -c <file> [-d]
-        ark -bcr <file> -on
-        ark -bcr <file> [-(a|st|vt)] [-s <start> <end>]
-        ark -bcr <file> [-cs] [-p <page>]
-        ark <file> [-d] [-L <lib_dir>]
+        arkscript -h
+        arkscript -v
+        arkscript --dev-info
+        arkscript -e <expression>
+        arkscript -c <file> [-d]
+        arkscript -bcr <file> -on
+        arkscript -bcr <file> [-(a|st|vt)] [-s <start> <end>]
+        arkscript -bcr <file> [-cs] [-p <page>]
+        arkscript <file> [-d] [-L <lib_dir>]
 
 OPTIONS
         -h, --help                  Display this message

--- a/src/arkscript/main.cpp
+++ b/src/arkscript/main.cpp
@@ -132,7 +132,7 @@ int main(int argc, char** argv)
         {
             case mode::help:
                 // clipp only supports streams
-                std::cout << make_man_page(cli, "ark", fmt)
+                std::cout << make_man_page(cli, "arkscript", fmt)
                                  .prepend_section("DESCRIPTION", "        ArkScript programming language")
                                  .append_section("LICENSE", "        Mozilla Public License 2.0")
                           << std::endl;


### PR DESCRIPTION
## Description
Hi again :) It's been a while. I was just messing around with the project again when I noticed that you'll receive deprecation warnings if you use `ark`; yet the output of the "--help" command still shows all the commands using the old `ark` program name. This PR fixes that that by changing the name of the executable on the help screen to be `arkscript`.

## Checklist

- [X] I have read the [Contributor guide](CONTRIBUTING.md)
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the documentation if needed
- [X] I have added tests that prove my fix/feature is working
- [X] New and existing tests pass locally with my changes
