### PR TITLE
CONTRIBUTING: Include note about building modules for test suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,9 +48,9 @@ run-on .\src
 
 ### Running the test suite
 
-ArkScript test suite should be ran from the root folder and the console module should have been compiled (it is used for colors). You can then run `./build/ark tests/arkscripts/unittests.ark --lib ./lib`.
+The ArkScript test suite requires the console module for text colors. You can build all the modules by including the `-DARK_BUILD_MODULES` CMake switch when building ArkScript. Once you have the modules built, you can run the ArkScript test suite from the root folder using `./build/arkscript tests/arkscript/unittests.ark --lib ./lib`.
 
-The standard library test suite should be ran from the root folder of the project (the console module needs to be copied to the folder). You can then run `./ark tests/all.ark --lib ./`.
+The standard library test suite should be ran from the root folder of the standard library project (the console module will need to be copied to the folder). You can run standard library test suite using `./arkscript tests/all.ark --lib ./`.
 
 ## C++ coding guidelines
 


### PR DESCRIPTION
## Description

Before running the test suite, the console module at the very least
needs to be compiled. This adds a note about building the modules before
running the test suite.

Additionally, I updated the path for the ArkScript test suite (the
correct path is `tests/arkscript/unittests.ark`).

I've also updated the name of the executable to be `arkscript` so users
do not get the deprecation warning when copying/pasting the command.

Finally, I noticed that there's a note about running the standard library
test suite using the `tests/all.ark` file, but I actually don't see that 
in the project. Is there a way to generate that file? I think I might be
missing something as I don't have that file in my project and I don't see
it here in the repo.

## Checklist

- [X] I have read the [Contributor guide](CONTRIBUTING.md)
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the documentation if needed
- [X] I have added tests that prove my fix/feature is working
- [X] New and existing tests pass locally with my changes
