### PR TITLE
Feature/suggestion

### DIFF
--- a/include/Ark/Compiler/Compiler.hpp
+++ b/include/Ark/Compiler/Compiler.hpp
@@ -289,6 +289,14 @@ namespace Ark
          * @param page the page where it should land, nullptr for current page
          */
         void pushNumber(uint16_t n, std::vector<uint8_t>* page = nullptr) noexcept;
+
+        /**
+         * @brief Suggest a symbol of what the user may have meant to input
+         *
+         * @param str the string
+         * @return std::string
+         */
+        std::string offerSuggestion(const std::string& str);
     };
 }
 

--- a/include/Ark/Utils.hpp
+++ b/include/Ark/Utils.hpp
@@ -2,16 +2,17 @@
  * @file Utils.hpp
  * @author Alexandre Plateau (lexplt.dev@gmail.com)
  * @brief Lots of utilities about string, filesystem and more
- * @version 0.2
+ * @version 0.3
  * @date 2020-10-27
- * 
+ *
  * @copyright Copyright (c) 2020-2021
- * 
+ *
  */
 
 #ifndef INCLUDE_ARK_UTILS_HPP
 #define INCLUDE_ARK_UTILS_HPP
 
+#include <algorithm>  // std::min
 #include <string>
 #include <iostream>
 #include <fstream>
@@ -25,10 +26,10 @@ namespace Ark::Utils
 {
     /**
      * @brief Cut a string into pieces, given a character separator
-     * 
-     * @param source 
-     * @param sep 
-     * @return std::vector<std::string> 
+     *
+     * @param source
+     * @param sep
+     * @return std::vector<std::string>
      */
     inline std::vector<std::string> splitString(const std::string& source, char sep)
     {
@@ -48,7 +49,7 @@ namespace Ark::Utils
 
     /**
      * @brief Checks if a string is a valid double
-     * 
+     *
      * @param s the string
      * @param output optional pointer to the output to avoid 2 conversions
      * @return true on success
@@ -66,20 +67,29 @@ namespace Ark::Utils
     /**
      * @brief Count the number of decimals for a double
      * @todo remove when migrating to libfmt
-     * 
-     * @param d 
-     * @return int 
+     *
+     * @param d
+     * @return int
      */
     int decPlaces(double d);
 
     /**
      * @brief Count the number of digits for a double
      * @todo remove when migrating to libfmt
-     * 
-     * @param d 
-     * @return int 
+     *
+     * @param d
+     * @return int
      */
     int digPlaces(double d);
+
+    /**
+     * @brief Calculate the Levenshtein distance between two strings
+     *
+     * @param str1
+     * @param str2
+     * @return int
+     */
+    int levenshteinDistance(const std::string& str1, const std::string& str2);
 }
 
 #endif

--- a/src/arkreactor/Utils.cpp
+++ b/src/arkreactor/Utils.cpp
@@ -29,4 +29,32 @@ namespace Ark::Utils
         }
         return digit_places;
     }
+
+    int levenshteinDistance(const std::string& str1, const std::string& str2)
+    {
+        std::size_t str1_len = str1.size();
+        std::size_t str2_len = str2.size();
+        std::vector<std::vector<int>> edit_distances(str1_len + 1, std::vector<int>(str2_len + 1, 0));
+
+        for (std::size_t i = 0; i < str1_len + 1; i++)
+            edit_distances[i][0] = i;
+
+        for (std::size_t j = 0; j < str2_len + 1; j++)
+            edit_distances[0][j] = j;
+
+        for (std::size_t i = 1; i < str1_len + 1; i++)
+        {
+            for (std::size_t j = 1; j < str2_len + 1; j++)
+            {
+                int indicator = str1[i - 1] == str2[j - 1] ? 0 : 1;
+                edit_distances[i][j] = std::min({
+                    edit_distances[i - 1][j] + 1,             // deletion
+                    edit_distances[i][j - 1] + 1,             // insertion
+                    edit_distances[i - 1][j - 1] + indicator  // substitution
+                });
+            }
+        }
+
+        return edit_distances[str1_len][str2_len];
+    }
 }


### PR DESCRIPTION
## Description

This branch adds the suggestion feature if we encounter a symbol that is undefined. This would close #352.

It's worth pointing out that, though the feature works, the example given in #352 used to explain how the feature should work will not work. To illustrate the problem, let's take the example that was given in that issue and lay it out line by line.


```
1 | (let gloublargh 12)
2 | (print gloublagrh)

```

The example won't offer a suggestion. Since line 1 isn't used, the Optimizer removes the symbol `gloublargh`. Then when the compiler hits line 2, it can't offer `gloublargh` as a suggestion since the symbol has been removed from the symbols table.

So obviously, if it's not removed from the defined symbols table, then the suggestion works. The following example does work since `gloublargh` is used at least once and the Optimizer never removes it.

```
1 | (let gloublargh 12)
2 | (print gloublagrh)
3 | (print gloublargh)

```

This PR adds the suggestion feature, but it's worth noting that there's an additional complication with this suggestion feature and the Optimizer.

Finally, I've noticed that you have another outstanding PR that heavily edits the Compiler. If you'd like, I can wait until that's merged, rebase my commits the dev branch after you've merged it, and leave a comment here once it's done.

Closes #352.

## Checklist

- [X] I have read the [Contributor guide](CONTRIBUTING.md)
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the documentation if needed
- [ ] I have added tests that prove my fix/feature is working
- [X] New and existing tests pass locally with my changes
