### PR TITLE
Feature/error context color

### DIFF
--- a/include/Ark/Compiler/AST/makeErrorCtx.hpp
+++ b/include/Ark/Compiler/AST/makeErrorCtx.hpp
@@ -16,7 +16,6 @@
 #include <string>
 
 #include <Ark/Compiler/AST/Node.hpp>
-#include <termcolor/termcolor.hpp>
 
 namespace Ark::internal
 {

--- a/include/Ark/Compiler/AST/makeErrorCtx.hpp
+++ b/include/Ark/Compiler/AST/makeErrorCtx.hpp
@@ -64,7 +64,7 @@ namespace Ark::internal
      * @param c
      * @return bool
      */
-    inline bool isPairableChar(const char& c)
+    inline bool isPairableChar(const char c)
     {
         return c == '(' || c == ')' || c == '[' || c == ']' || c == '{' || c == '}';
     }

--- a/include/Ark/Compiler/AST/makeErrorCtx.hpp
+++ b/include/Ark/Compiler/AST/makeErrorCtx.hpp
@@ -2,10 +2,10 @@
  * @file makeErrorCtx.hpp
  * @author Alexandre Plateau (lexplt.dev@gmail.com)
  * @brief Create string error context for AST errors
- * @version 0.1
- * @date 2020-10-27
+ * @version 0.2
+ * @date 2022-02-19
  *
- * @copyright Copyright (c) 2020-2021
+ * @copyright Copyright (c) 2020-2022
  *
  */
 
@@ -20,6 +20,13 @@
 
 namespace Ark::internal
 {
+    struct LineColorContextCounts
+    {
+        int open_parentheses = 0;
+        int open_square_braces = 0;
+        int open_curly_braces = 0;
+    };
+
     /**
      * @brief Construct an error message based on a given node
      * @details It opens the related file at the line and column of the node,
@@ -42,6 +49,26 @@ namespace Ark::internal
      * @return std::string the complete generated error message
      */
     std::string makeTokenBasedErrorCtx(const std::string& match, std::size_t line, std::size_t col, const std::string& code);
+
+    /**
+     * @brief Add colors to highlight matching parentheses/curly braces/square braces on a line
+     *
+     * @param line the line of code to colorize
+     * @param line_color_context_counts a LineColorContextCounts to manipulate the running counts of open pairings
+     * @return std::string a colorized line of code
+     */
+    std::string colorizeLine(const std::string& line, LineColorContextCounts& line_color_context_counts);
+
+    /**
+     * @brief Check if the character passed in can be paired (parentheses, curly braces, or square braces)
+     *
+     * @param c
+     * @return bool
+     */
+    inline bool isPairableChar(const char& c)
+    {
+        return c == '(' || c == ')' || c == '[' || c == ']' || c == '{' || c == '}';
+    }
 }
 
 #endif

--- a/include/Ark/Compiler/AST/makeErrorCtx.hpp
+++ b/include/Ark/Compiler/AST/makeErrorCtx.hpp
@@ -4,9 +4,9 @@
  * @brief Create string error context for AST errors
  * @version 0.1
  * @date 2020-10-27
- * 
+ *
  * @copyright Copyright (c) 2020-2021
- * 
+ *
  */
 
 #ifndef COMPILER_AST_MAKEERRORCTX_HPP
@@ -16,6 +16,7 @@
 #include <string>
 
 #include <Ark/Compiler/AST/Node.hpp>
+#include <termcolor/termcolor.hpp>
 
 namespace Ark::internal
 {
@@ -23,9 +24,9 @@ namespace Ark::internal
      * @brief Construct an error message based on a given node
      * @details It opens the related file at the line and column of the node,
      *          and display context, plus underline the problem with a serie of ^.
-     * 
-     * @param message 
-     * @param node 
+     *
+     * @param message
+     * @param node
      * @return std::string the complete generated error message
      */
     std::string makeNodeBasedErrorCtx(const std::string& message, const Node& node);
@@ -33,7 +34,7 @@ namespace Ark::internal
     /**
      * @brief Construct an error message based on a given match in the code
      * @details Mostly used by the Lexer and Parser since they don't have Nodes to work on
-     * 
+     *
      * @param match the identified token, causing a problem
      * @param line line of the token
      * @param col starting column of the token

--- a/src/arkreactor/Compiler/AST/makeErrorCtx.cpp
+++ b/src/arkreactor/Compiler/AST/makeErrorCtx.cpp
@@ -45,7 +45,7 @@ namespace Ark::internal
 
     std::string colorizeLine(const std::string& line, LineColorContextCounts& line_color_context_counts)
     {
-        std::vector<std::ostream& (*)(std::ostream & stream)> pairing_color {
+        constexpr std::array<std::ostream& (*)(std::ostream & stream), 3> pairing_color {
             termcolor::bright_blue,
             termcolor::bright_green,
             termcolor::bright_yellow

--- a/src/arkreactor/Compiler/AST/makeErrorCtx.cpp
+++ b/src/arkreactor/Compiler/AST/makeErrorCtx.cpp
@@ -28,13 +28,15 @@ namespace Ark::internal
             {
                 os << "      | ";
 
-                for (std::size_t j = 0; (sym_size > col_start) ? false : (j < col_start); ++j)
-                {
-                    if (j < col_start)  // padding of spaces
-                        os << " ";
-                    else if (j >= col_start && j <= col_end)  // underline the error
-                        os << termcolor::red << "^";
-                }
+                // padding of spaces
+                for (std::size_t i = 0; i < col_start; ++i)
+                    os << " ";
+
+                // underline the error
+                os << termcolor::red;
+                for (std::size_t i = col_start; i < col_end; ++i)
+                    os << "^";
+
                 os << termcolor::reset << "\n";
             }
         }

--- a/src/arkreactor/Compiler/AST/makeErrorCtx.cpp
+++ b/src/arkreactor/Compiler/AST/makeErrorCtx.cpp
@@ -11,6 +11,7 @@ namespace Ark::internal
 {
     void makeContext(std::ostream& os, const std::string& code, std::size_t line, std::size_t col_start, std::size_t sym_size)
     {
+        os << termcolor::colorize;
         std::vector<std::string> ctx = Utils::splitString(code, '\n');
 
         std::size_t col_end = std::min(col_start + sym_size, ctx[line].size());
@@ -19,7 +20,7 @@ namespace Ark::internal
 
         for (std::size_t loop = first; loop < last; ++loop)
         {
-            os << std::setw(5) << (loop + 1) << " | " << ctx[loop] << "\n";
+            os << termcolor::green << std::setw(5) << (loop + 1) << termcolor::reset << " | " << ctx[loop] << "\n";
 
             if (loop == line)
             {
@@ -30,9 +31,9 @@ namespace Ark::internal
                     if (j < col_start)  // padding of spaces
                         os << " ";
                     else if (j >= col_start && j <= col_end)  // underline the error
-                        os << "^";
+                        os << termcolor::red << "^";
                 }
-                os << "\n";
+                os << termcolor::reset << "\n";
             }
         }
     }

--- a/src/arkreactor/Compiler/AST/makeErrorCtx.cpp
+++ b/src/arkreactor/Compiler/AST/makeErrorCtx.cpp
@@ -15,7 +15,7 @@ namespace Ark::internal
         os << termcolor::colorize;
         std::vector<std::string> ctx = Utils::splitString(code, '\n');
 
-        std::size_t col_end = std::min(col_start + sym_size, ctx[line].size());
+        std::size_t col_end = std::min<std::size_t>(col_start + sym_size, ctx[line].size());
         std::size_t first = line >= 3 ? line - 3 : 0;
         std::size_t last = (line + 3) <= ctx.size() ? line + 3 : ctx.size();
         LineColorContextCounts line_color_context_counts;

--- a/src/arkreactor/Compiler/AST/makeErrorCtx.cpp
+++ b/src/arkreactor/Compiler/AST/makeErrorCtx.cpp
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include <iomanip>
+#include <termcolor/termcolor.hpp>
 
 #include <Ark/Constants.hpp>
 #include <Ark/Files.hpp>


### PR DESCRIPTION
## Description

This PR adds colors to the Error Context as detailed in #267.

It adds a green color for the line numbers, a red color for the underline errors, and color pairings for parentheses/square braces/curly braces. I picked three colors that I thought looked nice in the terminal, but we can always play with them and change them. :)

![colors](https://user-images.githubusercontent.com/19653787/154826711-d022ab4d-483f-4b50-86a9-78159b905a71.png)

As you can see from the picture above, the underline doesn't print (it hasn't been working for me since I've picked the project up again). The final commit in this PR is a fix for the underline in the Error Context. With that commit included, you can see the underline working.

![colors_underline](https://user-images.githubusercontent.com/19653787/154826748-9ec179bb-067c-4da7-91ca-be28e9dd98bb.png)

Closes #267 

## Checklist

- [X] I have read the [Contributor guide](CONTRIBUTING.md)
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the documentation if needed
- [ ] I have added tests that prove my fix/feature is working
- [X] New and existing tests pass locally with my changes

