### PR TITLE
fix: the error message should always display the correct number of arguments it received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 - fixed underline bug in the error context
+- changing the way we count received arguments in arity / type errors for failed function call
 
 ### Deprecated
 

--- a/include/Ark/TypeChecker.hpp
+++ b/include/Ark/TypeChecker.hpp
@@ -98,7 +98,7 @@ namespace Ark::types
      * @param contracts types contracts the function can follow
      * @param args provided argument list
      */
-    ARK_API void generateError(std::string_view funcname, const std::vector<Contract>& contracts, const std::vector<Value>& args);
+    ARK_API void generateError [[noreturn]] (std::string_view funcname, const std::vector<Contract>& contracts, const std::vector<Value>& args);
 }
 
 #endif

--- a/include/Ark/VM/VM.hpp
+++ b/include/Ark/VM/VM.hpp
@@ -133,6 +133,7 @@ namespace Ark
 
         // just a nice little trick for operator[] and for pop
         Value m_no_value = internal::Builtins::nil;
+        Value m_undefined_value;
 
         void* m_user_pointer;  ///< needed to pass data around when binding ArkScript in a program
                                // Note: This is a non owned pointer.

--- a/include/Ark/VM/inline/VM.inl
+++ b/include/Ark/VM/inline/VM.inl
@@ -133,7 +133,7 @@ inline Value* VM::pop(internal::ExecutionContext& context)
         return &context.stack[context.sp];
     }
     else
-        return &m_no_value;
+        return &m_undefined_value;
 }
 
 inline void VM::push(const Value& value, internal::ExecutionContext& context)


### PR DESCRIPTION
# Fixing error messages

## Description

Changing the way we count received arguments in arity / type errors for failed function call. The stack now returns a `Value(ValueType::Undefined)` when it's empty (as a failsafe) instead of Nil. The typechecker takes this in account to generate error messages accordingly.

## Checklist

- [x] I have read the [Contributor guide](CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation if needed
- [ ] I have added tests that prove my fix/feature is working
- [x] New and existing tests pass locally with my changes
