### PR TITLE
Fixing issue 379: giving multiple paths to --lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 - fixed underline bug in the error context
+- the CLI can now take a list of paths to the standard library, separated by ';'
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ OPTIONS
         -s, --slice                 Select a slice of instructions in the bytecode
         -cs, --code                 Display only the code segments
         -p, --page                  Set the bytecode reader code segment to display
-        -L, --lib                   Set the location of the ArkScript standard library
+        -L, --lib                   Set the location of the ArkScript standard library. Paths can be
+                                    delimited by ';'
 
 LICENSE
         Mozilla Public License 2.0

--- a/src/arkscript/main.cpp
+++ b/src/arkscript/main.cpp
@@ -103,7 +103,7 @@ int main(int argc, char** argv)
                 ,
                 // shouldn't change now, the lib option is fine and working
                 (
-                    option("-L", "--lib").doc("Set the location of the ArkScript standard library")
+                    option("-L", "--lib").doc("Set the location of the ArkScript standard library. Paths can be delimited by ';'")
                     & value("lib_dir", libdir)
                 )
             )
@@ -126,7 +126,7 @@ int main(int argc, char** argv)
         using namespace Ark;
 
         if (!libdir.empty())
-            libenv.push_back(libdir);
+            libenv = Utils::splitString(libdir, ';');
 
         switch (selected)
         {


### PR DESCRIPTION
# giving multiple paths to --lib

## Description

We can now give multiple paths to --lib when using the CLI.

## Checklist

- [x] I have read the [Contributor guide](CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation if needed
- [ ] I have added tests that prove my fix/feature is working
- [x] New and existing tests pass locally with my changes
