### PR TITLE
Macros should always be evaluated and argcount has to work with both Symbols and anonymous Functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 - printing a closure will now print its fields instead of `Closure<1432>`
+- macros are always evaluated, even when they aren't any user defined macro
+- argcount works on symbols and anonymous functions
 
 ### Deprecated
 

--- a/tests/arkscript/macro-tests.ark
+++ b/tests/arkscript/macro-tests.ark
@@ -157,6 +157,9 @@
     (set tests (assert-eq (argcount test_func) 3 "macro argcount" tests))
     (set tests (assert-eq (argcount test_func1) 2 "macro argcount" tests))
     (set tests (assert-eq (argcount test_func1_2) 1 "macro argcount" tests))
+    (set tests (assert-eq (argcount (fun () ())) 0 "macro argcount" tests))
+    (set tests (assert-eq (argcount (fun (a) ())) 1 "macro argcount" tests))
+    (set tests (assert-eq (argcount (fun (a b g h u t) ())) 6 "macro argcount" tests))
     (set tests (assert-eq (test_func 1 2 3) (test_func1 2 3) "macro partial" tests))
     (set tests (assert-eq (test_func 1 2 3) (test_func1_2 3) "macro partial" tests))
 


### PR DESCRIPTION
# Pull request template

## Description

The macro processor should always run, even if they aren't any user defined macros. Also, argcount now checks for the type of the passed node to prevent crashes (it was assuming everything was a symbol). It will work with both symbols and anonymous functions.

Closes #383 

## Checklist

- [x] I have read the [Contributor guide](CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation if needed
- [x] I have added tests that prove my fix/feature is working
- [x] New and existing tests pass locally with my changes
