### PR TITLE
fix: adding a proxy header for termcolor to avoid errors on errors due to Windows

### DIFF
--- a/include/termcolor/proxy.hpp
+++ b/include/termcolor/proxy.hpp
@@ -1,0 +1,10 @@
+#ifndef INCLUDE_TERMCOLOR_PROXY_HPP
+#define INCLUDE_TERMCOLOR_PROXY_HPP
+
+#ifdef WIN32
+#    define NOMINMAX
+#endif
+
+#include <termcolor/termcolor.hpp>
+
+#endif

--- a/src/arkreactor/Compiler/AST/Node.cpp
+++ b/src/arkreactor/Compiler/AST/Node.cpp
@@ -1,6 +1,6 @@
 #include <Ark/Compiler/AST/Node.hpp>
 
-#include <termcolor/termcolor.hpp>
+#include <termcolor/proxy.hpp>
 
 #include <Ark/Exceptions.hpp>
 

--- a/src/arkreactor/Compiler/AST/makeErrorCtx.cpp
+++ b/src/arkreactor/Compiler/AST/makeErrorCtx.cpp
@@ -2,7 +2,7 @@
 
 #include <vector>
 #include <iomanip>
-#include <termcolor/termcolor.hpp>
+#include <termcolor/proxy.hpp>
 
 #include <Ark/Constants.hpp>
 #include <Ark/Files.hpp>

--- a/src/arkreactor/Compiler/BytecodeReader.cpp
+++ b/src/arkreactor/Compiler/BytecodeReader.cpp
@@ -5,7 +5,7 @@
 #undef abs
 #include <Ark/Utils.hpp>
 
-#include <termcolor/termcolor.hpp>
+#include <termcolor/proxy.hpp>
 #include <picosha2.h>
 
 namespace Ark

--- a/src/arkreactor/TypeChecker.cpp
+++ b/src/arkreactor/TypeChecker.cpp
@@ -3,8 +3,7 @@
 #include <limits>
 #include <numeric>
 #include <algorithm>
-#define NOMINMAX
-#include <termcolor/termcolor.hpp>
+#include <termcolor/proxy.hpp>
 
 #include <Ark/Exceptions.hpp>
 

--- a/src/arkreactor/VM/State.cpp
+++ b/src/arkreactor/VM/State.cpp
@@ -11,7 +11,7 @@
 
 #include <stdlib.h>
 #include <picosha2.h>
-#include <termcolor/termcolor.hpp>
+#include <termcolor/proxy.hpp>
 
 namespace Ark
 {

--- a/src/arkreactor/VM/VM.cpp
+++ b/src/arkreactor/VM/VM.cpp
@@ -1,11 +1,9 @@
-#define NOMINMAX
-
 #include <Ark/VM/VM.hpp>
 
 #include <numeric>
 #include <limits>
 
-#include <termcolor/termcolor.hpp>
+#include <termcolor/proxy.hpp>
 #include <Ark/Files.hpp>
 #include <Ark/Utils.hpp>
 #include <Ark/TypeChecker.hpp>

--- a/src/arkscript/main.cpp
+++ b/src/arkscript/main.cpp
@@ -5,8 +5,7 @@
 #include <limits>
 
 #include <clipp.h>
-#define NOMINMAX
-#include <termcolor/termcolor.hpp>
+#include <termcolor/proxy.hpp>
 
 #include <Ark/Ark.hpp>
 #include <Ark/REPL/Repl.hpp>


### PR DESCRIPTION
# Pull request template

## Description

Now including termcolor through a proxy header.

## Checklist

- [x] I have read the [Contributor guide](CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation if needed
- [ ] I have added tests that prove my fix/feature is working
- [x] New and existing tests pass locally with my changes
