### PR TITLE
chore: updating the logging strategy (streams/printf removed, using fmt::print)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - more documentation about the compiler implementation
 - more documentation about the virtual machine
 - closures can be now be compared field per field: `(= closure1 closure2)` will work only if they have the same fields (name) and if the values match
+- upgraded lib fmt to 9.1.0
 
 ### Removed
 - removing the custom string, replacing it with std::string (the format engine of the custom string had a lot of memory leaks)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@
 - more documentation about the virtual machine
 - closures can be now be compared field per field: `(= closure1 closure2)` will work only if they have the same fields (name) and if the values match
 - upgraded lib fmt to 9.1.0
+- using fmtlib nearly everywhere possible to replace streams and printf mixed with termcolor
 
 ### Removed
 - removing the custom string, replacing it with std::string (the format engine of the custom string had a lot of memory leaks)
 - `Utils::digPlaces` and `Utils::decPlaces` got removed as they were no longer needed
 - removed unused `NodeType::Closure`
 - removed deprecated code (`list:removeAt`, `ark` executable now replaced by `arkscript`)
+- removed unused debug level attribute from the lexer, macro executor, macro processor, json compiler and compiler
 
 ## [3.4.0] - 2022-09-12
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # files needed for the library ArkReactor
 file(GLOB_RECURSE SOURCE_FILES
     ${ark_SOURCE_DIR}/src/arkreactor/*.cpp
-    ${ark_SOURCE_DIR}/lib/fmt/src/*.cc)
+    ${ark_SOURCE_DIR}/lib/fmt/src/format.cc)
 
 add_library(ArkReactor SHARED ${SOURCE_FILES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,8 @@ if (ARK_BUILD_EXE)
     set(EXE_SOURCES
         ${ark_SOURCE_DIR}/src/arkscript/REPL/Utils.cpp
         ${ark_SOURCE_DIR}/src/arkscript/REPL/Repl.cpp
-        ${ark_SOURCE_DIR}/src/arkscript/main.cpp)
+        ${ark_SOURCE_DIR}/src/arkscript/main.cpp
+        ${ark_SOURCE_DIR}/lib/fmt/src/format.cc)
 
     add_executable(arkscript ${EXE_SOURCES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # files needed for the library ArkReactor
 file(GLOB_RECURSE SOURCE_FILES
-    ${ark_SOURCE_DIR}/src/arkreactor/*.cpp
-    ${ark_SOURCE_DIR}/lib/fmt/src/format.cc)
+    ${ark_SOURCE_DIR}/src/arkreactor/*.cpp)
 
 add_library(ArkReactor SHARED ${SOURCE_FILES})
 
@@ -97,15 +96,15 @@ endif()
 
 # Link libraries
 
-add_subdirectory("${ark_SOURCE_DIR}/lib/termcolor" EXCLUDE_FROM_ALL)
+add_subdirectory(${ark_SOURCE_DIR}/lib/termcolor EXCLUDE_FROM_ALL)
+add_subdirectory(${ark_SOURCE_DIR}/lib/fmt EXCLUDE_FROM_ALL)
 
 target_include_directories(ArkReactor
     PUBLIC
-    "${ark_SOURCE_DIR}/lib/utf8_decoder/"
-    "${ark_SOURCE_DIR}/lib/picosha2/"
-    "${ark_SOURCE_DIR}/lib/fmt/include")
+    ${ark_SOURCE_DIR}/lib/utf8_decoder/
+    ${ark_SOURCE_DIR}/lib/picosha2/)
 
-target_link_libraries(ArkReactor PUBLIC termcolor)
+target_link_libraries(ArkReactor PUBLIC termcolor fmt::fmt-header-only)
 
 if (UNIX OR LINUX)
     if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
@@ -186,8 +185,7 @@ if (ARK_BUILD_EXE)
     set(EXE_SOURCES
         ${ark_SOURCE_DIR}/src/arkscript/REPL/Utils.cpp
         ${ark_SOURCE_DIR}/src/arkscript/REPL/Repl.cpp
-        ${ark_SOURCE_DIR}/src/arkscript/main.cpp
-        ${ark_SOURCE_DIR}/lib/fmt/src/format.cc)
+        ${ark_SOURCE_DIR}/src/arkscript/main.cpp)
 
     add_executable(arkscript ${EXE_SOURCES})
 

--- a/include/Ark/Compiler/AST/Lexer.hpp
+++ b/include/Ark/Compiler/AST/Lexer.hpp
@@ -29,9 +29,8 @@ namespace Ark::internal
         /**
          * @brief Construct a new Lexer object
          *
-         * @param debug the debug level
          */
-        explicit Lexer(unsigned debug) noexcept;
+        Lexer() noexcept;
 
         /**
          * @brief Give code to tokenize and create the list of tokens
@@ -48,7 +47,6 @@ namespace Ark::internal
         std::vector<Token>& tokens() noexcept;
 
     private:
-        unsigned m_debug;
         std::vector<Token> m_tokens;
 
         inline constexpr bool isHexChar(char chr)

--- a/include/Ark/Compiler/BytecodeReader.hpp
+++ b/include/Ark/Compiler/BytecodeReader.hpp
@@ -4,9 +4,9 @@
  * @brief A bytecode disassembler for ArkScript
  * @version 0.4
  * @date 2020-10-27
- * 
+ *
  * @copyright Copyright (c) 2020-2022
- * 
+ *
  */
 
 #ifndef ARK_COMPILER_BYTECODEREADER_HPP
@@ -37,35 +37,35 @@ namespace Ark
      * @brief This class is just a helper to
      * - check if a bytecode is valid
      * - display it in a human readable way by using the opcode names
-     * 
+     *
      */
     class ARK_API BytecodeReader
     {
     public:
         /**
          * @brief Construct a new Bytecode Reader object
-         * 
+         *
          */
         BytecodeReader() = default;
 
         /**
          * @brief Construct needed data before displaying information about a given file
-         * 
+         *
          * @param file filename of the bytecode file
          */
         void feed(const std::string& file);
 
         /**
          * @brief Return the bytecode object constructed
-         * 
-         * @return const bytecode_t& 
+         *
+         * @return const bytecode_t&
          */
         const bytecode_t& bytecode() noexcept;
 
         /**
          * @brief Return the read timestamp from the bytecode file
-         * 
-         * @return unsigned long long 
+         *
+         * @return unsigned long long
          */
         unsigned long long timestamp();
 
@@ -87,7 +87,7 @@ namespace Ark
 
         /**
          * @brief Read a number from the bytecode, under the instruction pointer i
-         * 
+         *
          * @param i this parameter is being modified to point to the next value
          * @return uint16_t the number we read (big endian)
          */

--- a/include/Ark/Compiler/BytecodeReader.hpp
+++ b/include/Ark/Compiler/BytecodeReader.hpp
@@ -2,10 +2,10 @@
  * @file BytecodeReader.hpp
  * @author Alexandre Plateau (lexplt.dev@gmail.com)
  * @brief A bytecode disassembler for ArkScript
- * @version 0.3
+ * @version 0.4
  * @date 2020-10-27
  * 
- * @copyright Copyright (c) 2020-2021
+ * @copyright Copyright (c) 2020-2022
  * 
  */
 

--- a/include/Ark/Compiler/Compiler.hpp
+++ b/include/Ark/Compiler/Compiler.hpp
@@ -85,9 +85,7 @@ namespace Ark
         std::vector<internal::ValTableElem> m_values;
         std::vector<std::vector<internal::Word>> m_code_pages;
         std::vector<std::vector<internal::Word>> m_temp_pages;  ///< we need temporary code pages for some compilations passes
-
         bytecode_t m_bytecode;
-        unsigned m_debug;  ///< the debug level of the compiler
 
         /**
          * @brief Push the file headers (magic, version used, timestamp)

--- a/include/Ark/Compiler/JsonCompiler.hpp
+++ b/include/Ark/Compiler/JsonCompiler.hpp
@@ -42,7 +42,6 @@ namespace Ark
         internal::Parser m_parser;
         internal::Optimizer m_optimizer;
         uint16_t m_options;
-        unsigned m_debug;  ///< the debug level of the compiler
 
         /**
          * @brief Compile a single node and return its representation

--- a/include/Ark/Compiler/Macros/Executor.hpp
+++ b/include/Ark/Compiler/Macros/Executor.hpp
@@ -31,9 +31,8 @@ namespace Ark::internal
          * @brief Construct a new Macro Executor object
          * 
          * @param macroprocessor 
-         * @param debug 
          */
-        MacroExecutor(MacroProcessor* macroprocessor, unsigned debug = 0);
+        explicit MacroExecutor(MacroProcessor* macroprocessor);
 
         /**
          * @brief Need a virtual destructor to correctly destory object.
@@ -59,7 +58,6 @@ namespace Ark::internal
         virtual bool canHandle(Node& node) = 0;
 
     protected:
-        unsigned int m_debug;
         MacroProcessor* m_macroprocessor;  // Note: Non owned pointer.
 
         /**

--- a/include/Ark/Compiler/Macros/Processor.hpp
+++ b/include/Ark/Compiler/Macros/Processor.hpp
@@ -32,10 +32,9 @@ namespace Ark::internal
         /**
          * @brief Construct a new Macro Processor object
          * 
-         * @param debug the debug level
          * @param options the options flags
          */
-        MacroProcessor(unsigned debug, uint16_t options) noexcept;
+        MacroProcessor(uint16_t options) noexcept;
 
         /**
          * @brief Send the complete AST (after the inclusions and stuff), and work on it
@@ -54,7 +53,6 @@ namespace Ark::internal
         friend class MacroExecutor;
 
     private:
-        unsigned m_debug;  ///< The debug level
         uint16_t m_options;
         Node m_ast;                                                   ///< The modified AST
         std::vector<std::unordered_map<std::string, Node>> m_macros;  ///< Handling macros in a scope fashion

--- a/include/Ark/REPL/Repl.hpp
+++ b/include/Ark/REPL/Repl.hpp
@@ -47,8 +47,7 @@ namespace Ark
         std::vector<std::string> m_libenv;
 
         inline void print_repl_header();
-        int count_open_parentheses(const std::string& line);
-        int count_open_braces(const std::string& line);
+        int count_open_group(const std::string& line, char left, char right);
         void trim_whitespace(std::string& line);
         void cui_setup();
     };

--- a/include/Ark/Utils.hpp
+++ b/include/Ark/Utils.hpp
@@ -12,7 +12,7 @@
 #ifndef INCLUDE_ARK_UTILS_HPP
 #define INCLUDE_ARK_UTILS_HPP
 
-#include <algorithm>  // std::min
+#include <algorithm>
 #include <string>
 #include <iostream>
 #include <fstream>
@@ -41,7 +41,7 @@ namespace Ark::Utils
             if (c != sep)
                 output.back() += c;
             else
-                output.emplace_back();  // add empty string
+                output.emplace_back();
         }
 
         return output;

--- a/include/Ark/VM/Value.hpp
+++ b/include/Ark/VM/Value.hpp
@@ -14,7 +14,7 @@
 
 #include <vector>
 #include <variant>
-#include <string>  // for conversions
+#include <string>
 #include <cinttypes>
 #include <iostream>
 #include <memory>
@@ -69,7 +69,7 @@ namespace Ark
     class ARK_API Value
     {
     public:
-        using ProcType = Value (*)(std::vector<Value>&, VM*);  // std::function<Value (std::vector<Value>&, VM*)>
+        using ProcType = Value (*)(std::vector<Value>&, VM*);
         using Iterator = std::vector<Value>::iterator;
         using ConstIterator = std::vector<Value>::const_iterator;
 

--- a/src/arkreactor/Builtins/IO.cpp
+++ b/src/arkreactor/Builtins/IO.cpp
@@ -64,7 +64,7 @@ namespace Ark::internal::Builtins::IO
         if (types::check(n, ValueType::String))
             fmt::print(n[0].string());
         else if (n.size() != 0)
-            types::generateError("input", { { types::Contract {{}}, types::Contract { { types::Typedef("prompt", ValueType::String) } } } }, n);
+            types::generateError("input", { { types::Contract {}, types::Contract { { types::Typedef("prompt", ValueType::String) } } } }, n);
 
         std::string line = "";
         std::getline(std::cin, line);

--- a/src/arkreactor/Builtins/IO.cpp
+++ b/src/arkreactor/Builtins/IO.cpp
@@ -64,7 +64,7 @@ namespace Ark::internal::Builtins::IO
         if (types::check(n, ValueType::String))
             fmt::print(n[0].string());
         else if (n.size() != 0)
-            types::generateError("input", { { types::Contract {}, types::Contract { { types::Typedef("prompt", ValueType::String) } } } }, n);
+            types::generateError("input", { { types::Contract {{}}, types::Contract { { types::Typedef("prompt", ValueType::String) } } } }, n);
 
         std::string line = "";
         std::getline(std::cin, line);

--- a/src/arkreactor/Compiler/AST/Lexer.cpp
+++ b/src/arkreactor/Compiler/AST/Lexer.cpp
@@ -11,8 +11,7 @@
 
 namespace Ark::internal
 {
-    Lexer::Lexer(unsigned debug) noexcept :
-        m_debug(debug)
+    Lexer::Lexer() noexcept
     {}
 
     void Lexer::feed(const std::string& code)

--- a/src/arkreactor/Compiler/AST/Lexer.cpp
+++ b/src/arkreactor/Compiler/AST/Lexer.cpp
@@ -1,6 +1,5 @@
 #include <Ark/Compiler/AST/Lexer.hpp>
 
-#include <cstdio>  // TODO remove
 #include <algorithm>
 #include <utility>
 #include <sstream>
@@ -39,11 +38,6 @@ namespace Ark::internal
         for (std::size_t pos = 0, end = code.size(); pos < end; ++pos)
         {
             char current = code[pos];
-
-            if (m_debug >= 5)
-                std::printf(
-                    "buffer: %s - ctrl_char: %s - current: '%c' - line: %zu, char: %zu\n",
-                    buffer.c_str(), ctrl_char.c_str(), current, line, character);
 
             if (!in_string)
             {
@@ -238,20 +232,6 @@ namespace Ark::internal
 
         if (!buffer.empty() && buffer[0] != '#')
             append_token_from_buffer();
-
-        // debugging information
-        if (m_debug > 3)
-        {
-            for (auto& last_token : m_tokens)
-            {
-                std::printf(
-                    "TokenType: %s\tLine: %zu\n[%zu\t]\tToken: %s\n",
-                    tokentype_string[static_cast<std::size_t>(last_token.type)].data(),
-                    last_token.line,
-                    last_token.col,
-                    last_token.token.c_str());
-            }
-        }
     }
 
     std::vector<Token>& Lexer::tokens() noexcept

--- a/src/arkreactor/Compiler/AST/Parser.cpp
+++ b/src/arkreactor/Compiler/AST/Parser.cpp
@@ -15,7 +15,7 @@ namespace Ark::internal
         m_debug(debug),
         m_libenv(lib_env),
         m_options(options),
-        m_lexer(debug),
+        m_lexer(),
         m_file(ARK_NO_NAME_FILE)
     {}
 

--- a/src/arkreactor/Compiler/AST/Parser.cpp
+++ b/src/arkreactor/Compiler/AST/Parser.cpp
@@ -3,6 +3,7 @@
 #include <optional>
 #include <algorithm>
 #include <sstream>
+#include <fmt/ostream.h>
 
 #include <Ark/Files.hpp>
 #include <Ark/Exceptions.hpp>
@@ -24,8 +25,6 @@ namespace Ark::internal
         if (filename != ARK_NO_NAME_FILE)
         {
             m_file = Utils::canonicalRelPath(filename);
-            if (m_debug >= 2)
-                std::cout << "New parser: " << m_file << '\n';
             m_parent_include.push_back(m_file);
         }
 
@@ -51,9 +50,9 @@ namespace Ark::internal
         // include files if needed
         checkForInclude(m_ast, m_ast);
 
-        if (m_debug >= 3)
-            std::cout << "(Parser) AST\n"
-                      << m_ast << "\n\n";
+        // FIXME
+        // if (m_debug >= 2)
+        //     fmt::print("Parser - AST\n{}\n\n", m_ast);
     }
 
     const Node& Parser::ast() const noexcept
@@ -355,8 +354,8 @@ namespace Ark::internal
         }
         else if (token.token == "!")
         {
-            if (m_debug >= 2)
-                std::cout << "Found a macro at " << token.line << ':' << token.col << " in " << m_file << '\n';
+            if (m_debug >= 3)
+                fmt::print("Found a macro at {}:{} in {}\n", token.line, token.col, m_file);
 
             // macros
             Node block = make_node(NodeType::Macro, token.line, token.col, m_file);
@@ -492,9 +491,6 @@ namespace Ark::internal
             // if we found an import statement, inspect it
             if (first.nodeType() == NodeType::Keyword && first.keyword() == Keyword::Import)
             {
-                if (m_debug >= 2)
-                    std::cout << "Import found in file: " << m_file << '\n';
-
                 if (n.constList()[1].nodeType() != NodeType::String)
                     throw TypeError("Arguments of import must be of type String");
 
@@ -549,14 +545,6 @@ namespace Ark::internal
         const std::string current_dir = Utils::getDirectoryFromPath(m_file) + "/";
         const std::string path = (current_dir != "/") ? current_dir + file : file;
 
-        if (m_debug >= 2)
-        {
-            std::cout << "path: " << path << " ; file: " << file << " ; libpath: ";
-            for (auto&& lib : m_libenv)
-                std::cout << lib << ":";
-            std::cout << "\nfilename: " << Utils::getFilenameFromPath(file) << '\n';
-        }
-
         // search in the current directory
         if (Utils::fileExists(path))
             return path;
@@ -601,7 +589,7 @@ namespace Ark::internal
         {
             int i = 0;
             for (const auto& node : P.ast().constList())
-                std::cout << (i++) << ": " << node << '\n';
+                os << (i++) << ": " << node << '\n';
         }
         else
             os << "Single item\n"

--- a/src/arkreactor/Compiler/Compiler.cpp
+++ b/src/arkreactor/Compiler/Compiler.cpp
@@ -19,14 +19,14 @@ namespace Ark
 
     Compiler::Compiler(unsigned debug, const std::vector<std::string>& libenv, uint16_t options) :
         m_parser(debug, options, libenv), m_optimizer(options),
-        m_options(options), m_debug(debug)
+        m_options(options)
     {}
 
     void Compiler::feed(const std::string& code, const std::string& filename)
     {
         m_parser.feed(code, filename);
 
-        MacroProcessor mp(m_debug, m_options);
+        MacroProcessor mp(m_options);
         mp.feed(m_parser.ast());
         m_optimizer.feed(mp.ast());
     }
@@ -93,9 +93,6 @@ namespace Ark
 
     void Compiler::saveTo(const std::string& file)
     {
-        if (m_debug >= 1)
-            fmt::print("Final bytecode size: {}B\n", m_bytecode.size() * sizeof(uint8_t));
-
         std::ofstream output(file, std::ofstream::binary);
         output.write(reinterpret_cast<char*>(&m_bytecode[0]), m_bytecode.size() * sizeof(uint8_t));
         output.close();

--- a/src/arkreactor/Compiler/Compiler.cpp
+++ b/src/arkreactor/Compiler/Compiler.cpp
@@ -5,8 +5,7 @@
 #include <limits>
 #include <filesystem>
 #include <picosha2.h>
-#include <termcolor/termcolor.hpp>
-#undef max
+#include <fmt/color.h>
 
 #include <Ark/Literals.hpp>
 #include <Ark/Utils.hpp>
@@ -95,7 +94,7 @@ namespace Ark
     void Compiler::saveTo(const std::string& file)
     {
         if (m_debug >= 1)
-            std::cout << "Final bytecode size: " << m_bytecode.size() * sizeof(uint8_t) << "B\n";
+            fmt::print("Final bytecode size: {}B\n", m_bytecode.size() * sizeof(uint8_t));
 
         std::ofstream output(file, std::ofstream::binary);
         output.write(reinterpret_cast<char*>(&m_bytecode[0]), m_bytecode.size() * sizeof(uint8_t));
@@ -265,7 +264,7 @@ namespace Ark
     void Compiler::compilerWarning(const std::string& message, const Node& node)
     {
         if (m_options & FeatureShowWarnings)
-            std::cerr << termcolor::yellow << "Warning " << termcolor::reset << makeNodeBasedErrorCtx(message, node) << "\n";
+            fmt::print("{} {}\n", fmt::styled("Warning", fmt::fg(fmt::color::yellow)), makeNodeBasedErrorCtx(message, node));
     }
 
     void Compiler::compileExpression(const Node& x, int p, bool is_result_unused, bool is_terminal, const std::string& var_name)

--- a/src/arkreactor/Compiler/JsonCompiler.cpp
+++ b/src/arkreactor/Compiler/JsonCompiler.cpp
@@ -13,14 +13,14 @@ namespace Ark
 
     JsonCompiler::JsonCompiler(unsigned debug, const std::vector<std::string>& libenv, uint16_t options) :
         m_parser(debug, options, libenv), m_optimizer(options),
-        m_options(options), m_debug(debug)
+        m_options(options)
     {}
 
     void JsonCompiler::feed(const std::string& code, const std::string& filename)
     {
         m_parser.feed(code, filename);
 
-        MacroProcessor mp(m_debug, m_options);
+        MacroProcessor mp(m_options);
         mp.feed(m_parser.ast());
         m_optimizer.feed(mp.ast());
     }

--- a/src/arkreactor/Compiler/Macros/Executor.cpp
+++ b/src/arkreactor/Compiler/Macros/Executor.cpp
@@ -4,8 +4,7 @@
 
 namespace Ark::internal
 {
-    MacroExecutor::MacroExecutor(MacroProcessor* macroprocessor, unsigned debug) :
-        m_debug(debug),
+    MacroExecutor::MacroExecutor(MacroProcessor* macroprocessor) :
         m_macroprocessor(macroprocessor)
     {}
 

--- a/src/arkreactor/Compiler/Macros/Processor.cpp
+++ b/src/arkreactor/Compiler/Macros/Processor.cpp
@@ -13,8 +13,8 @@
 
 namespace Ark::internal
 {
-    MacroProcessor::MacroProcessor(unsigned debug, uint16_t options) noexcept :
-        m_debug(debug), m_options(options)
+    MacroProcessor::MacroProcessor(uint16_t options) noexcept :
+        m_options(options)
     {
         // create executors pipeline
         m_executor_pipeline = MacroExecutorPipeline(
@@ -33,10 +33,6 @@ namespace Ark::internal
         // to be able to modify it
         m_ast = ast;
         process(m_ast, 0);
-
-        // FIXME
-        // if (m_debug >= 2)
-        //     fmt::print("MacroProcessor - AST after processing macros\n{}\n", m_ast);
     }
 
     const Node& MacroProcessor::ast() const noexcept

--- a/src/arkreactor/Compiler/Macros/Processor.cpp
+++ b/src/arkreactor/Compiler/Macros/Processor.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <utility>
+#include <fmt/ostream.h>
 
 #include <Ark/Exceptions.hpp>
 #include <Ark/Compiler/AST/makeErrorCtx.hpp>
@@ -29,18 +30,13 @@ namespace Ark::internal
 
     void MacroProcessor::feed(const Node& ast)
     {
-        if (m_debug >= 2)
-            std::cout << "Processing macros...\n";
-
         // to be able to modify it
         m_ast = ast;
         process(m_ast, 0);
 
-        if (m_debug >= 3)
-        {
-            std::cout << "(MacroProcessor) AST after processing macros\n";
-            std::cout << m_ast << '\n';
-        }
+        // FIXME
+        // if (m_debug >= 2)
+        //     fmt::print("MacroProcessor - AST after processing macros\n{}\n", m_ast);
     }
 
     const Node& MacroProcessor::ast() const noexcept

--- a/src/arkreactor/TypeChecker.cpp
+++ b/src/arkreactor/TypeChecker.cpp
@@ -78,6 +78,11 @@ namespace Ark::types
             }
             fmt::print("\n");
         }
+
+        if (contract.arguments.size() == 0)
+        {
+            fmt::print(" -> no argument\n");
+        }
     }
 
     [[noreturn]] void generateError(std::string_view funcname, const std::vector<Contract>& contracts, const std::vector<Value>& args)
@@ -104,7 +109,7 @@ namespace Ark::types
         if (min_argc != max_argc)
         {
             fmt::print(
-                "between {} argument{} and {} argument{}\n",
+                "between {} argument{} and {} argument{}",
                 fmt::styled(min_argc, fmt::fg(fmt::color::yellow)),
                 (min_argc > 1 ? "s" : ""),
                 fmt::styled(max_argc, fmt::fg(fmt::color::yellow)),
@@ -115,7 +120,7 @@ namespace Ark::types
         }
         else
         {
-            fmt::print("{} argument{}\n", fmt::styled(min_argc, fmt::fg(fmt::color::yellow)), (min_argc > 1 ? "s" : ""));
+            fmt::print("{} argument{}", fmt::styled(min_argc, fmt::fg(fmt::color::yellow)), (min_argc > 1 ? "s" : ""));
 
             if (sanitizedArgs.size() != min_argc)
                 correct_argcount = false;
@@ -123,11 +128,13 @@ namespace Ark::types
 
         if (!correct_argcount)
             fmt::print(" but got {}\n", fmt::styled(sanitizedArgs.size(), fmt::fg(fmt::color::red)));
+        else
+            fmt::print("\n");
 
         displayContract(contracts[0], sanitizedArgs);
         for (std::size_t i = 1, end = contracts.size(); i < end; ++i)
         {
-            fmt::print("Alternative {}:\n", i + 1);
+            fmt::print("Alternative {}:\n", i);
             displayContract(contracts[i], sanitizedArgs);
         }
 

--- a/src/arkreactor/VM/State.cpp
+++ b/src/arkreactor/VM/State.cpp
@@ -9,9 +9,8 @@
 #    pragma warning(disable : 4996)
 #endif
 
-#include <stdlib.h>
+#include <fmt/color.h>
 #include <picosha2.h>
-#include <termcolor/proxy.hpp>
 
 namespace Ark
 {
@@ -34,7 +33,7 @@ namespace Ark
             else
             {
                 if (m_debug_level >= 1)
-                    std::cout << termcolor::yellow << "Warning" << termcolor::reset << " no std library was found and ARKSCRIPT_PATH was not supplied" << std::endl;
+                    fmt::print("{} no std library was found and ARKSCRIPT_PATH was not supplied\n", fmt::styled("Warning", fmt::fg(fmt::color::yellow)));
             }
         }
     }
@@ -54,7 +53,7 @@ namespace Ark
         catch (const std::exception& e)
         {
             result = false;
-            std::printf("%s\n", e.what());
+            fmt::print("{}\n", e.what());
         }
 
         return result;
@@ -71,7 +70,7 @@ namespace Ark
         catch (const std::exception& e)
         {
             result = false;
-            std::printf("%s\n", e.what());
+            fmt::print("{}\n", e.what());
         }
 
         return result;
@@ -95,12 +94,12 @@ namespace Ark
         }
         catch (const std::exception& e)
         {
-            std::printf("%s\n", e.what());
+            fmt::print("{}\n", e.what());
             return false;
         }
         catch (...)
         {
-            std::printf("Unknown lexer-parser-or-compiler error (%s)\n", file.c_str());
+            fmt::print("Unknown lexer-parser-or-compiler error ({})\n", file);
             return false;
         }
 
@@ -111,8 +110,7 @@ namespace Ark
     {
         if (!Utils::fileExists(file))
         {
-            std::cerr << termcolor::red << "Can not find file '" << file << "'\n"
-                      << termcolor::reset;
+            fmt::print(fmt::fg(fmt::color::red), "Can not find file '{}'\n", file);
             return false;
         }
 
@@ -124,7 +122,7 @@ namespace Ark
         }
         catch (const std::exception& e)
         {
-            std::printf("%s\n", e.what());
+            fmt::print("{}\n", e.what());
             return false;
         }
 
@@ -161,12 +159,12 @@ namespace Ark
         }
         catch (const std::exception& e)
         {
-            std::printf("%s\n", e.what());
+            fmt::print("{}\n", e.what());
             return false;
         }
         catch (...)
         {
-            std::printf("Unknown lexer-parser-or-compiler error\n");
+            fmt::print("Unknown lexer-parser-or-compiler error\n");
             return false;
         }
 

--- a/src/arkreactor/VM/State.cpp
+++ b/src/arkreactor/VM/State.cpp
@@ -225,10 +225,10 @@ namespace Ark
 
         if (major != ARK_VERSION_MAJOR)
         {
-            std::string str_version = std::to_string(major) + "." +
-                std::to_string(minor) + "." +
-                std::to_string(patch);
-            throwStateError("Compiler and VM versions don't match: " + str_version + " and " + ARK_VERSION_STR);
+            throwStateError(
+                fmt::format("Compiler and VM versions don't match: {}.{}.{} and {}.{}.{}\n",
+                            major, minor, patch,
+                            ARK_VERSION_MAJOR, ARK_VERSION_MINOR, ARK_VERSION_PATCH));
         }
 
         using timestamp_t = unsigned long long;

--- a/src/arkreactor/VM/VM.cpp
+++ b/src/arkreactor/VM/VM.cpp
@@ -1126,9 +1126,9 @@ namespace Ark
         auto d = std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time);
 
         fmt::print("\nInstructions executed: {}\nTime spent: {} us\n{} MIPS\n",
-            instructions_executed,
-            d.count(),
-            static_cast<double>(instructions_executed) / d.count());
+                   instructions_executed,
+                   d.count(),
+                   static_cast<double>(instructions_executed) / d.count());
 #endif
 
         return m_exit_code;

--- a/src/arkscript/main.cpp
+++ b/src/arkscript/main.cpp
@@ -1,16 +1,14 @@
-#include <cstdio>
 #include <iostream>
 #include <optional>
 #include <filesystem>
 #include <limits>
 
 #include <clipp.h>
-#include <termcolor/proxy.hpp>
+#include <fmt/core.h>
 
 #include <Ark/Ark.hpp>
-#include <Ark/REPL/Repl.hpp>
-
 #include <Ark/Files.hpp>
+#include <Ark/REPL/Repl.hpp>
 #include <Ark/Compiler/JsonCompiler.hpp>
 
 int main(int argc, char** argv)
@@ -138,28 +136,28 @@ int main(int argc, char** argv)
                 break;
 
             case mode::version:
-                std::printf("Version %i.%i.%i\n", ARK_VERSION_MAJOR, ARK_VERSION_MINOR, ARK_VERSION_PATCH);
+                fmt::print("Version {}.{}.{}\n", ARK_VERSION_MAJOR, ARK_VERSION_MINOR, ARK_VERSION_PATCH);
                 break;
 
             case mode::dev_info:
             {
-                std::printf(
-                    "Have been compiled with %s, options: %s\n\n"
-                    "sizeof(Ark::Value)    = %zuB\n"
-                    "      sizeof(Value_t) = %zuB\n"
-                    "      sizeof(ValueType) = %zuB\n"
-                    "      sizeof(ProcType)  = %zuB\n"
-                    "      sizeof(Ark::Closure)  = %zuB\n"
-                    "      sizeof(Ark::UserType) = %zuB\n"
+                fmt::print(
+                    "Have been compiled with {}, options: {}\n\n"
+                    "sizeof(Ark::Value)    = {}B\n"
+                    "      sizeof(Value_t) = {}B\n"
+                    "      sizeof(ValueType) = {}B\n"
+                    "      sizeof(ProcType)  = {}B\n"
+                    "      sizeof(Ark::Closure)  = {}B\n"
+                    "      sizeof(Ark::UserType) = {}B\n"
                     "\nVirtual Machine\n"
-                    "sizeof(Ark::VM)       = %zuB\n"
-                    "      sizeof(Ark::State)    = %zuB\n"
-                    "      sizeof(Ark::Scope)    = %zuB\n"
-                    "      sizeof(ExecutionContext) = %zuB\n"
+                    "sizeof(Ark::VM)       = {}B\n"
+                    "      sizeof(Ark::State)    = {}B\n"
+                    "      sizeof(Ark::Scope)    = {}B\n"
+                    "      sizeof(ExecutionContext) = {}B\n"
                     "\nMisc\n"
-                    "    sizeof(vector<Ark::Value>) = %zuB\n"
-                    "    sizeof(std::string)   = %zuB\n"
-                    "    sizeof(char)          = %zuB\n",
+                    "    sizeof(vector<Ark::Value>) = {}B\n"
+                    "    sizeof(std::string)   = {}B\n"
+                    "    sizeof(char)          = {}B\n",
                     ARK_COMPILER, ARK_COMPILATION_OPTIONS,
                     // value
                     sizeof(Ark::Value),
@@ -194,7 +192,7 @@ int main(int argc, char** argv)
 
                 if (!state.doFile(file))
                 {
-                    std::cerr << "Could not compile file at " << file << "\n";
+                    fmt::print("Could not compile file at {}\n", file);
                     return -1;
                 }
 
@@ -209,7 +207,7 @@ int main(int argc, char** argv)
 
                 if (!state.doFile(file))
                 {
-                    std::cerr << "Could not run file at " << file << "\n";
+                    fmt::print("Could not run file at {}\n");
                     return -1;
                 }
 
@@ -217,10 +215,10 @@ int main(int argc, char** argv)
                 int out = vm.run();
 
 #ifdef ARK_PROFILER_COUNT
-                std::printf(
+                fmt::print(
                     "\n\nValue\n"
                     "=====\n"
-                    "\tCreations: %u\n\tCopies: %u\n\tMoves: %u\n\n\tCopy coeff: %f",
+                    "\tCreations: {}\n\tCopies: {}\n\tMoves: {}\n\n\tCopy coeff: {}",
                     Ark::internal::value_creations,
                     Ark::internal::value_copies,
                     Ark::internal::value_moves,
@@ -237,7 +235,7 @@ int main(int argc, char** argv)
 
                 if (!state.doString(eval_expresion))
                 {
-                    std::cerr << "Could not evaluate expression\n";
+                    fmt::print("Could not evaluate expression\n");
                     return -1;
                 }
 
@@ -249,7 +247,7 @@ int main(int argc, char** argv)
             {
                 Ark::JsonCompiler jcompiler(debug, libenv, options);
                 jcompiler.feed(Ark::Utils::readFile(file), file);
-                std::cout << jcompiler.compile() << std::endl;
+                fmt::print("{}\n", jcompiler.compile());
                 break;
             }
 
@@ -271,7 +269,7 @@ int main(int argc, char** argv)
                 }
                 catch (const std::exception& e)
                 {
-                    std::printf("%s\n", e.what());
+                    fmt::print("{}\n", e.what());
                 }
                 break;
             }
@@ -280,7 +278,7 @@ int main(int argc, char** argv)
     else
     {
         for (const auto& arg : wrong)
-            std::printf("'%s' ins't a valid argument\n", arg.c_str());
+            fmt::print("'{}' ins't a valid argument\n", arg);
 
         // clipp only supports streams
         std::cout << make_man_page(cli, "arkscript", fmt)

--- a/src/arkscript/main.cpp
+++ b/src/arkscript/main.cpp
@@ -207,7 +207,7 @@ int main(int argc, char** argv)
 
                 if (!state.doFile(file))
                 {
-                    fmt::print("Could not run file at {}\n");
+                    fmt::print("Could not run file at {}\n", file);
                     return -1;
                 }
 


### PR DESCRIPTION
# Updating the logging strategy

## Description

Removes std::cout/std::cerr/std::printf and uses fmt::print almost everywhere (if possible).

Closes #248 

## Checklist

- [x] I have read the [Contributor guide](CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation if needed
- [ ] I have added tests that prove my fix/feature is working
- [x] New and existing tests pass locally with my changes
