### PR TITLE
fix: export LD_LIBRARY_PATH to add lib64 to avoid unknown symbols

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY .git .git
 COPY lib lib
 COPY .gitmodules .
 
-# Get submodules and remove unneccesery files
+# Get submodules and remove unneccesary files
 RUN git submodule update --init --recursive \
     && rm -rf `find . -type d -name ".git"` \
     && rm .gitmodules
@@ -29,7 +29,7 @@ COPY Installer.iss.in .
 COPY CMakeLists.txt .
 COPY cmake cmake
 COPY --from=submodule-initializor /out .
-RUN cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DARK_BUILD_EXE=On \
+RUN cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DARK_BUILD_EXE=On \
     && cmake --build build --target arkscript
 
 FROM alpine:3.12 AS organizer
@@ -48,5 +48,6 @@ RUN apk --no-cache add cmake
 # Install Ark
 COPY --from=organizer /out/ark .
 RUN cmake --install build --config Release
+ENV LD_LIBRARY_PATH=/usr/local/lib64
 
 ENTRYPOINT [ "arkscript" ]


### PR DESCRIPTION
# Fix dockerfile

## Description

- Add ENV LD_LIBRARY_PATH to the dockerfile
- Force clang usage when building arkscript

Closes #431

## Checklist

- [x] I have read the [Contributor guide](CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation if needed
- [ ] I have added tests that prove my fix/feature is working
- [x] New and existing tests pass locally with my changes
