### PR TITLE
feat!: $* macro as it is not needed anymore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         config:
           - {
             os: ubuntu-latest, name: "Ubuntu Clang 15", cc: "clang-15", cxx: "clang++-15",
-            artifact: "ubuntu-clang-15", sanitizers: "On", preconfigure: ""
+            artifact: "ubuntu-clang-15", sanitizers: "Off", preconfigure: ""
           }
           - {
             os: ubuntu-latest, name: "Ubuntu Clang 15 (valgrind)", cc: "clang-15", cxx: "clang++-15",

--- a/include/Ark/Compiler/AST/Parser.hpp
+++ b/include/Ark/Compiler/AST/Parser.hpp
@@ -44,7 +44,6 @@ namespace Ark::internal
         std::optional<Node> functionArgs();
         std::optional<Node> function();
         std::optional<Node> macroCondition();
-        std::optional<Node> macroBlock();
         std::optional<Node> macroArgs();
         std::optional<Node> macro();
         std::optional<Node> functionCall();

--- a/src/arkreactor/Compiler/AST/Parser.cpp
+++ b/src/arkreactor/Compiler/AST/Parser.cpp
@@ -87,11 +87,6 @@ namespace Ark::internal
         else
             backtrack(position);
 
-        if (auto result = macroBlock())
-            return result;
-        else
-            backtrack(position);
-
         if (auto result = macro(); result.has_value())
             return result;
         else
@@ -502,34 +497,6 @@ namespace Ark::internal
             newlineOrComment();
         }
 
-        return leaf;
-    }
-
-    std::optional<Node> Parser::macroBlock()
-    {
-        if (!accept(IsChar('(')))
-            return std::nullopt;
-        newlineOrComment();
-
-        if (!oneOf({ "$*" }))
-            return std::nullopt;
-        newlineOrComment();
-
-        Node leaf(NodeType::List);
-
-        while (!isEOF())
-        {
-            if (auto value = nodeOrValue(); value.has_value())
-            {
-                leaf.push_back(value.value());
-                newlineOrComment();
-            }
-            else
-                break;
-        }
-
-        newlineOrComment();
-        expect(IsChar(')'));
         return leaf;
     }
 

--- a/tests/arkscript/macro-tests.ark
+++ b/tests/arkscript/macro-tests.ark
@@ -146,7 +146,7 @@
         ($if (> x 1)
             (suffix-dup sym (- x 1)))
         (symcat sym x)})
-    (let magic_func (fun ($* (suffix-dup a 3)) (- a1 a2 a3)))
+    (let magic_func (fun ((suffix-dup a 3)) (- a1 a2 a3)))
     (set tests (assert-eq (magic_func 1 2 3) (- 1 2 3) "macro symdup" tests))
 
     ($ partial (func ...defargs) {


### PR DESCRIPTION
## Description

Removed macro `$*` used to expand another macro inside the AST, which was a temporary work around for a bug in the parser, that didn't handle macros inside functions argument blocks.

## Checklist

- [x] I have read the [Contributor guide](CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation if needed
- [x] I have added tests that prove my fix/feature is working
- [x] New and existing tests pass locally with my changes
