### PR TITLE
fix(parser, formatter): slightly changes the way newlines are inserted

### DIFF
--- a/src/arkreactor/Compiler/AST/Parser.cpp
+++ b/src/arkreactor/Compiler/AST/Parser.cpp
@@ -869,10 +869,10 @@ namespace Ark::internal
             if (newlineOrComment(&comment))
                 result.value().attachCommentAfter(comment);
 
-            if (!suffix(')'))
-                errorMissingSuffix(')', name);
             if (result->isListLike())
                 setNodePosAndFilename(result->list().back());
+            if (!suffix(')'))
+                errorMissingSuffix(')', name);
 
             comment.clear();
             if (spaceComment(&comment))

--- a/tests/unittests/resources/FormatterSuite/conditions.expected
+++ b/tests/unittests/resources/FormatterSuite/conditions.expected
@@ -6,6 +6,7 @@
 (if (cond)
   (do)
   (stuff))
+
 # conditions in functions are on their own line
 (fun ()
   (if true 0))

--- a/tests/unittests/resources/FormatterSuite/field.expected
+++ b/tests/unittests/resources/FormatterSuite/field.expected
@@ -1,4 +1,5 @@
 (let a foo.closure.name)
+
 (foo.closure.name
   # test
   this.bar.egg.qux)


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and which issue is fixed, as well as context and relevant motivation. -->

This example
```
(let arg (if (>= (len sys:args) 1) (toNumber (@ sys:args 0)) nil))
(let i (if (nil? arg) 100 arg))

(mut n i)
(while (> n 1) {
    (print (str:format "{} Bottles of beer on the wall\n{} bottles of beer\nTake one down, pass it around" n n))
    (set n (- n 1))
    (print (str:format "{} Bottles of beer on the wall." n))})
```

Was formatted like this before this change

```
(let arg (if (>= (len sys:args) 1) (toNumber (@ sys:args 0)) nil))
(let i (if (nil? arg) 100 arg))
(mut n i)
(while (> n 1) {
  (print (str:format "{} Bottles of beer on the wall\n{} bottles of beer\nTake one down, pass it around" n n))
  (set n (- n 1))
  (print (str:format "{} Bottles of beer on the wall." n)) })
```

The line spacing between nodes wasn't preserved.

## Checklist

- [ ] I have read the [Contributor guide](CONTRIBUTING.md)
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation if needed
- [x] I have added tests that prove my fix/feature is working
- [x] New and existing tests pass locally with my changes
