### PR TITLE
ci(static analysis): show only files modified in the lizard report

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -21,12 +21,10 @@ jobs:
         id: lizard
         shell: bash
         run: |
-          content=$(python .github/launch-lizard.py)
-          content="${content//'%'/'%25'}"
-          content="${content//$'\n'/'%0A'}"
-          content="${content//$'\r'/'%0D'}"
-          # echo "report=$content" >> $GITHUB_OUTPUT
-          echo ::set-output name=report::$content
+          content=$(python .github/launch-lizard.py $(git diff HEAD..dev --name-only))
+          echo "LIZARD_REPORT<<EOF" >> $GITHUB_ENV
+          echo "$content" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
       - name: Run cppcheck
         id: cppcheck
@@ -53,9 +51,12 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             ## Static analysis report
-            ${{ steps.lizard.outputs.report }}
+            ${{ env.LIZARD_REPORT }}
+            
             ---
+            
             ### CppCheck report
+            
             ```
             ${{ steps.cppcheck.outputs.report }}
             ```


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and which issue is fixed, as well as context and relevant motivation. -->

Shows only the lizard report for the files modified by a PR. The others are hidden in a spoiler to reduce noise.

## Checklist

- [ ] I have read the [Contributor guide](CONTRIBUTING.md)
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation if needed
- [ ] I have added tests that prove my fix/feature is working
- [ ] New and existing tests pass locally with my changes
