### PR TITLE
Bench/vm no sharedptr scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - removing the custom string, replacing it with std::string (the format engine of the custom string had a lot of memory leaks)
 - `Utils::digPlaces` and `Utils::decPlaces` got removed as they were no longer needed
 - removed deprecated code (`list:removeAt`, `ark` executable now replaced by `arkscript`)
+- removed `VM::getUserPointer` and `VM::setUserPointer`
 
 ## [3.5.0] - 2023-02-19
 ### Added

--- a/include/Ark/VM/ExecutionContext.hpp
+++ b/include/Ark/VM/ExecutionContext.hpp
@@ -14,6 +14,7 @@
 
 #include <array>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <cinttypes>
 
@@ -39,9 +40,9 @@ namespace Ark::internal
         uint16_t last_symbol = std::numeric_limits<uint16_t>::max();
 
         std::array<Value, VMStackSize> stack;
-        std::vector<uint8_t> scope_count_to_delete;
-        std::optional<Scope_t> saved_scope;
-        std::vector<Scope_t> locals;
+        std::vector<std::shared_ptr<Scope>> stacked_closure_scopes;
+        std::optional<Scope> saved_scope;
+        std::vector<Scope> locals;
 
         ExecutionContext() noexcept :
             primary(ExecutionContext::Count == 0)

--- a/include/Ark/VM/Scope.hpp
+++ b/include/Ark/VM/Scope.hpp
@@ -35,6 +35,13 @@ namespace Ark::internal
         Scope() noexcept;
 
         /**
+         * @brief Merge values from this scope as refs in the other scope
+         * @details This scope must be kept alive for the ref to be used
+         * @param other
+         */
+        void mergeRefInto(Scope& other);
+
+        /**
          * @brief Put a value in the scope
          *
          * @param id The symbol id of the variable

--- a/include/Ark/VM/VM.hpp
+++ b/include/Ark/VM/VM.hpp
@@ -236,8 +236,6 @@ namespace Ark
         //                locals related
         // ================================================
 
-        inline void createNewScope(internal::ExecutionContext& context) noexcept;
-
         /**
          * @brief Find the nearest variable of a given id
          *

--- a/include/Ark/VM/VM.hpp
+++ b/include/Ark/VM/VM.hpp
@@ -113,20 +113,6 @@ namespace Ark
         void exit(int code) noexcept;
 
         /**
-         * @brief Set the User Pointer object
-         *
-         * @param ptr Pointer to data NOT owned by the VM, to be used later
-         */
-        void setUserPointer(void* ptr) noexcept;
-
-        /**
-         * @brief Retrieves the stored pointer
-         *
-         * @return void*
-         */
-        void* getUserPointer() noexcept;
-
-        /**
          * @brief Create an execution context and returns it
          * @details This method is thread-safe VM wise.
          *
@@ -175,9 +161,6 @@ namespace Ark
         // just a nice little trick for operator[] and for pop
         Value m_no_value = internal::Builtins::nil;
         Value m_undefined_value;
-
-        void* m_user_pointer;  ///< needed to pass data around when binding ArkScript in a program
-                               // Note: This is a non owned pointer.
 
         /**
          * @brief Run ArkScript bytecode inside a try catch to retrieve all the exceptions and display a stack trace if needed

--- a/include/Ark/VM/Value/Closure.hpp
+++ b/include/Ark/VM/Value/Closure.hpp
@@ -27,14 +27,6 @@ namespace Ark::internal
 {
     class Scope;
 
-    /**
-     * @brief Scope handling
-     *
-     * A scope is defined as a shared pointer to a list of local variables
-     *  because a Closure could continue to leave when the local variables list
-     *  has been closed by the virtual machine
-     */
-    using Scope_t = std::shared_ptr<Scope>;
     using PageAddr_t = uint16_t;
 
     /**
@@ -53,32 +45,47 @@ namespace Ark::internal
         /**
          * @brief Construct a new Closure object
          *
-         * @param scope_ptr the scope of the function turned into a closure
+         * @param scope the scope of the function turned into a closure
          * @param pa the current page address of the function turned into a closure
          */
-        Closure(Scope_t&& scope_ptr, PageAddr_t pa) noexcept;
+        Closure(Scope&& scope, PageAddr_t pa) noexcept;
 
         /**
          * @brief Construct a new Closure object
          *
-         * @param scope_ptr the scope of the function turned into a closure
+         * @param scope the scope of the function turned into a closure
          * @param pa the current page address of the function turned into a closure
          */
-        Closure(const Scope_t& scope_ptr, PageAddr_t pa) noexcept;
+        Closure(const Scope& scope, PageAddr_t pa) noexcept;
+
+        /**
+         * @brief Construct a new Closure object
+         * @param scope_ptr a shared pointer to the scope of the function turned into a closure
+         * @param pa the current page address of the function turned into a closure
+         */
+        Closure(const std::shared_ptr<Scope>& scope_ptr, PageAddr_t pa) noexcept;
 
         /**
          * @brief Return the scope held by the object
          *
-         * @return const Scope_t&
+         * @return const Scope&
          */
-        [[nodiscard]] const Scope_t& scope() const noexcept;
+        [[nodiscard]] inline const Scope& scope() const noexcept { return *m_scope.get(); }
 
         /**
          * @brief Return a reference to the scope held by the object
          *
-         * @return Scope_t&
+         * @return Scope&
          */
-        Scope_t& refScope() noexcept;
+        [[nodiscard]] inline Scope& refScope() noexcept { return *m_scope.get(); }
+
+        /**
+         * @brief Return a reference to the shared pointer representing the scope
+         * @details The scope has to be kept alive somewhere or all its variables will be destroyed.
+         *
+         * @return const std::shared_ptr<Scope>&
+         */
+        [[nodiscard]] inline const std::shared_ptr<Scope>& scopePtr() const { return m_scope; }
 
         /**
          * @brief Return the page address of the object
@@ -99,7 +106,7 @@ namespace Ark::internal
         friend ARK_API_INLINE bool operator<(const Closure& A, const Closure& B) noexcept;
 
     private:
-        Scope_t m_scope;
+        std::shared_ptr<Scope> m_scope;
         // keep track of the code page number, in case we need it later
         PageAddr_t m_page_addr;
     };

--- a/src/arkreactor/VM/VM.cpp
+++ b/src/arkreactor/VM/VM.cpp
@@ -24,9 +24,7 @@ namespace Ark
     using namespace internal;
 
     VM::VM(State& state) noexcept :
-        m_state(state), m_exit_code(0),
-        m_running(false),
-        m_user_pointer(nullptr)
+        m_state(state), m_exit_code(0), m_running(false)
     {
         m_execution_contexts.emplace_back(std::make_unique<ExecutionContext>())->locals.reserve(4);
     }
@@ -67,8 +65,6 @@ namespace Ark
     Value& VM::operator[](const std::string& name) noexcept
     {
         ExecutionContext& context = *m_execution_contexts.front();
-
-        // const std::lock_guard<std::mutex> lock(m_mutex);
 
         // find id of object
         auto it = std::find(m_state.m_symbols.begin(), m_state.m_symbols.end(), name);
@@ -167,20 +163,6 @@ namespace Ark
     {
         m_exit_code = code;
         m_running = false;
-    }
-
-    // ------------------------------------------
-    //               user pointer
-    // ------------------------------------------
-
-    void VM::setUserPointer(void* ptr) noexcept
-    {
-        m_user_pointer = ptr;
-    }
-
-    void* VM::getUserPointer() noexcept
-    {
-        return m_user_pointer;
     }
 
     ExecutionContext* VM::createAndGetContext()

--- a/src/arkreactor/VM/Value/Closure.cpp
+++ b/src/arkreactor/VM/Value/Closure.cpp
@@ -11,25 +11,20 @@ namespace Ark::internal
         m_page_addr(0)
     {}
 
-    Closure::Closure(Scope_t&& scope_ptr, PageAddr_t pa) noexcept :
-        m_scope(scope_ptr),
+    Closure::Closure(Scope&& scope, PageAddr_t pa) noexcept :
+        m_scope(std::make_shared<Scope>(scope)),
         m_page_addr(pa)
     {}
 
-    Closure::Closure(const Scope_t& scope_ptr, PageAddr_t pa) noexcept :
-        m_scope(scope_ptr),
+    Closure::Closure(const Scope& scope, PageAddr_t pa) noexcept :
+        m_scope(std::make_shared<Scope>(scope)),
         m_page_addr(pa)
     {}
 
-    const Scope_t& Closure::scope() const noexcept
-    {
-        return m_scope;
-    }
-
-    Scope_t& Closure::refScope() noexcept
-    {
-        return m_scope;
-    }
+    Closure::Closure(const std::shared_ptr<Scope>& scope_ptr, Ark::internal::PageAddr_t pa) noexcept :
+        m_scope(scope_ptr),
+        m_page_addr(pa)
+    {}
 
     void Closure::toString(std::ostream& os, VM& vm) const noexcept
     {

--- a/tests/arkscript/vm-tests.ark
+++ b/tests/arkscript/vm-tests.ark
@@ -12,6 +12,20 @@
 (let closure_3 (make 3 2 3))
 (let closure_4 (make2 1 2 3))
 
+(let inner 0)
+(let call (fun () {
+    (set val 5)
+    (set inner 12) }))
+(let get (fun () [val inner]))
+(let child (fun (&inner &call &get) ()))
+(mut val 1)
+(let parent (fun (&val &child) ()))
+
+(let create-human (fun (name age) {
+    (let set-age (fun (new-age) (set age new-age)))
+    (fun (&set-age &name &age) ()) }))
+(let bob (create-human "Bob" 38))
+
 (test:suite vm {
     (test:case "arithmetic operations" {
         (test:eq (+ 1 2) 3)
@@ -114,4 +128,12 @@
         (test:neq closure_1 closure_4)
         (test:neq closure_2 closure_3)
         (test:neq closure_1 closure_3)
-        (test:neq closure closure_1) })})
+        (test:neq closure closure_1)
+
+        (test:eq bob.age 38)
+        (bob.set-age 40)
+        (test:eq bob.age 40)
+
+        (test:eq (parent.child.get) [1 0])
+        (parent.child.call)
+        (test:eq (parent.child.get) [5 12]) })})

--- a/tests/benchmarks/compare.py
+++ b/tests/benchmarks/compare.py
@@ -116,7 +116,8 @@ def main(files: List[str]):
                 "real_time\ncpu_time",
                 f"{baseline.real_time}{baseline.time_unit}\n{baseline.cpu_time}{baseline.time_unit}"
             ] + [
-                f"{diff.dt_real_time} ({diff.dt_rt_percent})\n{diff.dt_cpu_time} ({diff.dt_ct_percent})" for
+                f"{diff.dt_real_time:.3f} ({diff.dt_rt_percent:.4f}%)\n{diff.dt_cpu_time:.3f} ({diff.dt_ct_percent:.4f}%)"
+                for
                 diff in diffs
             ])
     print(tabulate(data, headers, tablefmt="presto"))

--- a/tests/benchmarks/results/1-d45d7ea1.csv
+++ b/tests/benchmarks/results/1-d45d7ea1.csv
@@ -1,0 +1,5 @@
+name,iterations,real_time,cpu_time,time_unit,bytes_per_second,items_per_second,label,error_occurred,error_message
+"quicksort",4910,0.144658,0.144202,ms,,,,,
+"ackermann/iterations:50",50,73.3681,73.094,ms,,,,,
+"fibonacci/iterations:100",100,6.19486,6.17405,ms,,,,,
+"man_or_boy",46800,0.0150181,0.0149741,ms,,,,,


### PR DESCRIPTION
## Description

Removes the need of shared_ptr for every scope creation in the VM, resulting in a 5 to 17% performance gain.

```
python3 tests/benchmarks/compare.py tests/benchmarks/results/0-684ea758.csv tests/benchmarks/results/1-d45d7ea1.csv          
                          |           | 0-684ea758   | 1-d45d7ea1
--------------------------+-----------+--------------+--------------------
 quicksort                | real_time | 0.152787ms   | -0.008 (-5.3205%)
                          | cpu_time  | 0.152334ms   | -0.008 (-0.0534%)
 ackermann/iterations:50  | real_time | 81.2917ms    | -7.924 (-9.7471%)
                          | cpu_time  | 80.9612ms    | -7.867 (-0.0972%)
 fibonacci/iterations:100 | real_time | 7.51618ms    | -1.321 (-17.5797%)
                          | cpu_time  | 7.4984ms     | -1.324 (-0.1766%)
 man_or_boy               | real_time | 0.015211ms   | -0.000 (-1.2682%)
                          | cpu_time  | 0.0151691ms  | -0.000 (-0.0129%)
```

## Checklist

- [ ] I have read the [Contributor guide](CONTRIBUTING.md)
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation if needed
- [ ] I have added tests that prove my fix/feature is working
- [ ] New and existing tests pass locally with my changes
