### PR TITLE
Feat/short circuit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - introduced `Ark::internal::Pass` to describe compiler passes: they all output an AST (parser, import solver, macro processor, and optimizer for now)
 - add `-f(no-)importsolver`, `-f(no-)macroprocessor` and `-f(no-)optimizer` to toggle on and off those compiler passes
 - added resolving `empty?` as a macro when possible
+- added short circuiting to `and` and `or` implementation
 
 ### Changed
 - instructions are on 4 bytes: 1 byte for the instruction, 1 byte of padding, 2 bytes for an immediate argument
@@ -80,6 +81,7 @@
 - removed `ARK_PROFILER_COUNT` define
 - removed useless `\0` escape in strings
 - removed `termcolor` dependency to rely on `fmt` for coloring outputs
+- removed `and` and `or` instructions in favor of a better implementation to support short circuiting
 
 ## [3.5.0] - 2023-02-19
 ### Added

--- a/include/Ark/Compiler/Common.hpp
+++ b/include/Ark/Compiler/Common.hpp
@@ -100,7 +100,7 @@ namespace Ark::internal
         "len", "empty?", "tail", "head",
         "nil?", "assert",
         "toNumber", "toString",
-        "@", "and", "or", "mod",
+        "@", "mod",
         "type", "hasField",
         "not"
     };

--- a/include/Ark/Compiler/Instructions.hpp
+++ b/include/Ark/Compiler/Instructions.hpp
@@ -58,7 +58,8 @@ namespace Ark::internal
         POP_LIST = 0x17,
         POP_LIST_IN_PLACE = 0x18,
         POP = 0x19,
-        LAST_COMMAND = 0x19,
+        DUP = 0x1a,
+        LAST_COMMAND = 0x1a,
 
         FIRST_OPERATOR = 0x20,
         ADD = 0x20,
@@ -80,15 +81,13 @@ namespace Ark::internal
         TO_NUM = 0x30,
         TO_STR = 0x31,
         AT = 0x32,
-        AND_ = 0x33,
-        OR_ = 0x34,
-        MOD = 0x35,
-        TYPE = 0x36,
-        HASFIELD = 0x37,
-        NOT = 0x38,
-        LAST_OPERATOR = 0x38,
+        MOD = 0x33,
+        TYPE = 0x34,
+        HASFIELD = 0x35,
+        NOT = 0x36,
+        LAST_OPERATOR = 0x36,
 
-        LAST_INSTRUCTION = 0x38
+        LAST_INSTRUCTION = 0x36
     };
 }
 

--- a/src/arkreactor/Compiler/BytecodeReader.cpp
+++ b/src/arkreactor/Compiler/BytecodeReader.cpp
@@ -404,7 +404,7 @@ namespace Ark
                             else if (inst == LOAD_SYMBOL)
                                 color_print_inst("LOAD_SYMBOL", Arg { ArgKind::Symbol, arg });
                             else if (inst == LOAD_CONST)
-                                color_print_inst("LOAD_CONST", Arg { ArgKind::Symbol, arg });
+                                color_print_inst("LOAD_CONST", Arg { ArgKind::Value, arg });
                             else if (inst == POP_JUMP_IF_TRUE)
                                 color_print_inst("POP_JUMP_IF_TRUE", Arg { ArgKind::Raw, arg });
                             else if (inst == STORE)
@@ -451,6 +451,8 @@ namespace Ark
                                 color_print_inst("POP_LIST_IN_PLACE");
                             else if (inst == POP)
                                 color_print_inst("POP");
+                            else if (inst == DUP)
+                                color_print_inst("DUP");
                             else if (inst == ADD)
                                 color_print_inst("ADD");
                             else if (inst == SUB)
@@ -489,10 +491,6 @@ namespace Ark
                                 color_print_inst("TO_STR");
                             else if (inst == AT)
                                 color_print_inst("AT");
-                            else if (inst == AND_)
-                                color_print_inst("AND_");
-                            else if (inst == OR_)
-                                color_print_inst("OR_");
                             else if (inst == MOD)
                                 color_print_inst("MOD");
                             else if (inst == TYPE)
@@ -502,10 +500,7 @@ namespace Ark
                             else if (inst == NOT)
                                 color_print_inst("NOT");
                             else
-                            {
-                                fmt::println("Unknown instruction: {:02x}", inst);
-                                return;
-                            }
+                                fmt::println("Unknown instruction");
                         }
                     }
                 }

--- a/src/arkreactor/Compiler/NameResolutionPass.cpp
+++ b/src/arkreactor/Compiler/NameResolutionPass.cpp
@@ -75,6 +75,9 @@ namespace Ark::internal
             m_language_symbols.emplace(ope);
         for (auto inst : listInstructions)
             m_language_symbols.emplace(inst);
+
+        m_language_symbols.emplace("and");
+        m_language_symbols.emplace("or");
     }
 
     void NameResolutionPass::process(const Node& ast)

--- a/src/arkreactor/VM/VM.cpp
+++ b/src/arkreactor/VM/VM.cpp
@@ -318,7 +318,7 @@ namespace Ark
 
                     case POP_JUMP_IF_TRUE:
                     {
-                        if (*popAndResolveAsPtr(context) == Builtins::trueSym)
+                        if (Value boolean = *popAndResolveAsPtr(context); !!boolean)
                             context.ip = arg * 4;  // instructions are 4 bytes
                         break;
                     }
@@ -360,7 +360,7 @@ namespace Ark
 
                     case POP_JUMP_IF_FALSE:
                     {
-                        if (*popAndResolveAsPtr(context) == Builtins::falseSym)
+                        if (Value boolean = *popAndResolveAsPtr(context); !boolean)
                             context.ip = arg * 4;  // instructions are 4 bytes
                         break;
                     }
@@ -682,6 +682,13 @@ namespace Ark
                         break;
                     }
 
+                    case DUP:
+                    {
+                        context.stack[context.sp] = context.stack[context.sp - 1];
+                        ++context.sp;
+                        break;
+                    }
+
 #pragma endregion
 
 #pragma region "Operators"
@@ -978,22 +985,6 @@ namespace Ark
                                 { { types::Contract { { types::Typedef("src", ValueType::List), types::Typedef("idx", ValueType::Number) } },
                                     types::Contract { { types::Typedef("src", ValueType::String), types::Typedef("idx", ValueType::Number) } } } },
                                 { a, *b });
-                        break;
-                    }
-
-                    case AND_:
-                    {
-                        Value *a = popAndResolveAsPtr(context), *b = popAndResolveAsPtr(context);
-
-                        push((*a == Builtins::trueSym && *b == Builtins::trueSym) ? Builtins::trueSym : Builtins::falseSym, context);
-                        break;
-                    }
-
-                    case OR_:
-                    {
-                        Value *a = popAndResolveAsPtr(context), *b = popAndResolveAsPtr(context);
-
-                        push((*b == Builtins::trueSym || *a == Builtins::trueSym) ? Builtins::trueSym : Builtins::falseSym, context);
                         break;
                     }
 

--- a/tests/arkscript/vm-tests.ark
+++ b/tests/arkscript/vm-tests.ark
@@ -102,6 +102,13 @@
         (test:eq (@ ["h" "e" "l" "l" "o"] -1) "o")
         (test:eq (@ ["h" "e" "l" "l" "o"] -4) "e") })
 
+    (test:case "Short-circuiting" {
+        (let falsy (fun () {
+            (test:expect false)
+            false }))
+        (test:expect (or true (falsy)))
+        (test:expect (not (and false (falsy)))) })
+
     (test:case "De Morgan's law" {
         (test:expect (and true true true))
         (test:expect (not (and true nil true)))


### PR DESCRIPTION
## Description

`and` and `or` should be able to short-circuit. Currently, the following code:

```lisp
(let foo (fun () {
  (print "ok")
  true }))
(and (foo) (foo))
```

would print `ok` twice (because the operator needs to evaluate each argument to give an answer).

However we can short-circuit on the first false value for `and`, and on the first `true` value for `or`, to avoid evaluating unneeded values. This PR implements exactly this behaviour, by removing the `AND_` and `OR_` instructions, adding a `DUP` instruction and using `POP_JUMP_IF_(TRUE|FALSE)`.

## Checklist

- [x] I have read the [Contributor guide](CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation if needed
- [x] I have added tests that prove my fix/feature is working
- [x] New and existing tests pass locally with my changes

---

~~Documentation will have to be updated since some instructions were removed and other have a new bytecode.~~
