### PR TITLE
Fix/formater missing comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - add `-f(no-)importsolver`, `-f(no-)macroprocessor` and `-f(no-)optimizer` to toggle on and off those compiler passes
 - added resolving `empty?` as a macro when possible
 - added short-circuiting to `and` and `or` implementation
+- added `--check` to the formatter as an option: returns 0 if the code is correctly formatted, 1 otherwise
 
 ### Changed
 - instructions are on 4 bytes: 1 byte for the instruction, 1 byte of padding, 2 bytes for an immediate argument

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - introduced `Ark::internal::Pass` to describe compiler passes: they all output an AST (parser, import solver, macro processor, and optimizer for now)
 - add `-f(no-)importsolver`, `-f(no-)macroprocessor` and `-f(no-)optimizer` to toggle on and off those compiler passes
 - added resolving `empty?` as a macro when possible
-- added short circuiting to `and` and `or` implementation
+- added short-circuiting to `and` and `or` implementation
 
 ### Changed
 - instructions are on 4 bytes: 1 byte for the instruction, 1 byte of padding, 2 bytes for an immediate argument
@@ -71,6 +71,7 @@
 - introduced `internal::listInstructions` with the different instructions, to be used by the compiler and name resolution pass
 - checking for forbidden variable/constant name in the name & scope resolution pass, to give errors to the user before compiling some weird code
 - repl completion and colors are now generated automatically from the builtins, keywords & operators
+- fixed formating of comments inside function declarations
 
 ### Removed
 - removed unused `NodeType::Closure`
@@ -81,7 +82,7 @@
 - removed `ARK_PROFILER_COUNT` define
 - removed useless `\0` escape in strings
 - removed `termcolor` dependency to rely on `fmt` for coloring outputs
-- removed `and` and `or` instructions in favor of a better implementation to support short circuiting
+- removed `and` and `or` instructions in favor of a better implementation to support short-circuiting
 
 ## [3.5.0] - 2023-02-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 - checking for forbidden variable/constant name in the name & scope resolution pass, to give errors to the user before compiling some weird code
 - repl completion and colors are now generated automatically from the builtins, keywords & operators
 - fixed formating of comments inside function declarations
+- renamed the macros `symcat` and `argcount` to `$symcat` and `$argcount` for uniformity
 
 ### Removed
 - removed unused `NodeType::Closure`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ You will find here a summary of the different things you should do / look up to 
     * HTTPS: `git clone https://github.com/<username>/Ark.git`
     * or SSH: `git clone git@github.com:<username>/Ark.git`
 * Install the pre-commit hooks: `pre-commit install` (you may need to [install pre-commit](https://pre-commit.com/#install) first)
-* Create a branch for your feature: `git checkout -b feat/my-awesome-idea`
+* Create a branch for your feature: `git switch -c feat/my-awesome-idea`
 * When you're done, push it to your fork and submit a pull request
 
 Don't know what to work on? No worries, we have a [list of things to do](https://github.com/ArkScript-lang/Ark/projects). Also, you can check the issues to find something to do!

--- a/README.md
+++ b/README.md
@@ -183,9 +183,13 @@ SYNOPSIS
         arkscript -v
         arkscript --dev-info
         arkscript -e <expression>
-        arkscript -c <file> [-d]
-        arkscript <file> [-d] [-L <lib_dir>]
-        arkscript -f <file> [--dry-run]
+        arkscript -c <file> [-d] [-f(importsolver|no-importsolver)]
+                  [-f(macroprocessor|no-macroprocessor)] [-f(optimizer|no-optimizer)]
+
+        arkscript <file> [-d] [-L <lib_dir>] [-f(importsolver|no-importsolver)]
+                  [-f(macroprocessor|no-macroprocessor)] [-f(optimizer|no-optimizer)]
+
+        arkscript -f <file> [--(dry-run|check)]
         arkscript --ast <file> [-d] [-L <lib_dir>]
         arkscript -bcr <file> -on
         arkscript -bcr <file> -a [-s <start> <end>]
@@ -202,18 +206,40 @@ OPTIONS
         -c, --compile               Compile the given program to bytecode, but do not run
         -d, --debug...              Increase debug level (default: 0)
 
+        -f(importsolver|no-importsolver)
+                                    Toggle on and off the import solver pass
+
+        -f(macroprocessor|no-macroprocessor)
+                                    Toggle on and off the macro processor pass
+
+        -f(optimizer|no-optimizer)  Toggle on and off the optimizer pass
+        -d, --debug...              Increase debug level (default: 0)
+
         -L, --lib                   Set the location of the ArkScript standard library. Paths can be
                                     delimited by ';'
 
+        -f(importsolver|no-importsolver)
+                                    Toggle on and off the import solver pass
+
+        -f(macroprocessor|no-macroprocessor)
+                                    Toggle on and off the macro processor pass
+
+        -f(optimizer|no-optimizer)  Toggle on and off the optimizer pass
         -f, --format                Format the given source file in place
         --dry-run                   Do not modify the file, only print out the changes
+        --check                     Check if a file formating is correctly, without modifying it.
+                                    Return 1 if formating is needed, 0 otherwise
 
         --ast                       Compile the given program and output its AST as JSON to stdout
         -d, --debug...              Increase debug level (default: 0)
+
         -L, --lib                   Set the location of the ArkScript standard library. Paths can be
                                     delimited by ';'
 
         -bcr, --bytecode-reader     Launch the bytecode reader
+        <file>                      If file isn't a bytecode file, the cached compiled will be
+                                    loaded ; if there are none, it will be compiled first
+
         -on, --only-names           Display only the bytecode segments names and sizes
         -a, --all                   Display all the bytecode segments (default)
         -st, --symbols              Display only the symbols table
@@ -223,7 +249,7 @@ OPTIONS
         -s, --slice                 Select a slice of instructions in the bytecode
 
 VERSION
-        4.0.0-86587c14
+        4.0.0-ff04fd55
 
 LICENSE
         Mozilla Public License 2.0

--- a/examples/macros.ark
+++ b/examples/macros.ark
@@ -1,10 +1,10 @@
 ($ suffix-dup (sym x) {
     ($if (> x 1)
         (suffix-dup sym (- x 1)))
-    (symcat sym x)})
+    ($symcat sym x)})
 
 ($ partial (func ...defargs) {
-    ($ bloc (suffix-dup a (- (argcount func) (len defargs))))
+    ($ bloc (suffix-dup a (- ($argcount func) (len defargs))))
     (fun (bloc) (func ...defargs bloc))
     ($undef bloc)})
 
@@ -12,8 +12,8 @@
 (let test_func1 (partial test_func 1))
 
 (print "Generated partial functions for test_func (a b c) => (* a b c)")
-(print "Expected arguments for test_func:  " (argcount test_func) ", expected " 3)
-(print "Expected arguments for test_func1: " (argcount test_func1) ", expected " 2)
+(print "Expected arguments for test_func:  " ($argcount test_func) ", expected " 3)
+(print "Expected arguments for test_func1: " ($argcount test_func1) ", expected " 2)
 (print "Calling them: " (test_func 1 2 3) " " (test_func1 2 3))
 
 ($ foo (a b) (+ a b))

--- a/include/Ark/Compiler/Common.hpp
+++ b/include/Ark/Compiler/Common.hpp
@@ -91,19 +91,37 @@ namespace Ark::internal
         "pop!"
     };
 
-    // This list is related to include/Ark/Compiler/Instructions.hpp
-    // from FIRST_OPERATOR, to LAST_OPERATOR
-    // The order is very important
-    constexpr std::array<std::string_view, 25> operators = {
-        "+", "-", "*", "/",
-        ">", "<", "<=", ">=", "!=", "=",
-        "len", "empty?", "tail", "head",
-        "nil?", "assert",
-        "toNumber", "toString",
-        "@", "mod",
-        "type", "hasField",
-        "not"
-    };
+    namespace Language
+    {
+        constexpr std::string_view And = "and";
+        constexpr std::string_view Or = "or";
+
+        constexpr std::string_view Symcat = "$symcat";
+        constexpr std::string_view Argcount = "$argcount";
+        constexpr std::string_view Repr = "$repr";
+        constexpr std::string_view Paste = "$paste";
+
+        constexpr std::array macros = {
+            Symcat,
+            Argcount,
+            Repr,
+            Paste
+        };
+
+        // This list is related to include/Ark/Compiler/Instructions.hpp
+        // from FIRST_OPERATOR, to LAST_OPERATOR
+        // The order is very important
+        constexpr std::array<std::string_view, 25> operators = {
+            "+", "-", "*", "/",
+            ">", "<", "<=", ">=", "!=", "=",
+            "len", "empty?", "tail", "head",
+            "nil?", "assert",
+            "toNumber", "toString",
+            "@", "mod",
+            "type", "hasField",
+            "not"
+        };
+    }
 }
 
 #endif

--- a/include/Ark/Compiler/Macros/Processor.hpp
+++ b/include/Ark/Compiler/Macros/Processor.hpp
@@ -58,7 +58,6 @@ namespace Ark::internal
         Node m_ast;                        ///< The modified AST
         std::vector<MacroScope> m_macros;  ///< Handling macros in a scope fashion
         std::vector<std::shared_ptr<MacroExecutor>> m_executors;
-        std::vector<std::string> m_predefined_macros;  ///< Already existing macros, non-keywords, non-builtins
         std::unordered_map<std::string, Node> m_defined_functions;
 
         /**

--- a/include/CLI/Formatter.hpp
+++ b/include/CLI/Formatter.hpp
@@ -22,11 +22,14 @@ public:
 
     [[nodiscard]] const std::string& output() const;
 
+    [[nodiscard]] bool codeModified() const;
+
 private:
     const std::string m_filename;
     bool m_dry_run;  ///< If true, only prints the formatted file instead of saving it to disk
     Ark::internal::Parser m_parser;
     std::string m_output;
+    bool m_updated;  ///< True if the original code now difer from the formatted one
 
     void processAst(const Ark::internal::Node& ast);
     void warnIfCommentsWereRemoved(const std::string& original_code, const std::string& filename);

--- a/src/arkreactor/Compiler/Compiler.cpp
+++ b/src/arkreactor/Compiler/Compiler.cpp
@@ -188,9 +188,9 @@ namespace Ark
 
     std::optional<uint8_t> Compiler::getOperator(const std::string& name) noexcept
     {
-        const auto it = std::ranges::find(internal::operators, name);
-        if (it != internal::operators.end())
-            return static_cast<uint8_t>(std::distance(internal::operators.begin(), it) + FIRST_OPERATOR);
+        const auto it = std::ranges::find(internal::Language::operators, name);
+        if (it != internal::Language::operators.end())
+            return static_cast<uint8_t>(std::distance(internal::Language::operators.begin(), it) + FIRST_OPERATOR);
         return std::nullopt;
     }
 
@@ -569,9 +569,9 @@ namespace Ark
         };
         const std::optional<ShortcircuitOp> maybe_shortcircuit =
             node.nodeType() == NodeType::Symbol
-            ? (node.string() == "and"
+            ? (node.string() == Language::And
                    ? std::make_optional(ShortcircuitOp::And)
-                   : (node.string() == "or"
+                   : (node.string() == Language::Or
                           ? std::make_optional(ShortcircuitOp::Or)
                           : std::nullopt))
             : std::nullopt;
@@ -712,7 +712,7 @@ namespace Ark
                             fmt::format(
                                 "can not create a chained expression (of length {}) for operator `{}'. You most likely forgot a `)'.",
                                 exp_count,
-                                operators[static_cast<std::size_t>(op.opcode - FIRST_OPERATOR)]),
+                                Language::operators[static_cast<std::size_t>(op.opcode - FIRST_OPERATOR)]),
                             x);
                 }
             }

--- a/src/arkreactor/Compiler/NameResolutionPass.cpp
+++ b/src/arkreactor/Compiler/NameResolutionPass.cpp
@@ -71,13 +71,13 @@ namespace Ark::internal
     {
         for (const auto& builtin : Builtins::builtins)
             m_language_symbols.emplace(builtin.first);
-        for (auto ope : operators)
+        for (auto ope : Language::operators)
             m_language_symbols.emplace(ope);
         for (auto inst : listInstructions)
             m_language_symbols.emplace(inst);
 
-        m_language_symbols.emplace("and");
-        m_language_symbols.emplace("or");
+        m_language_symbols.emplace(Language::And);
+        m_language_symbols.emplace(Language::Or);
     }
 
     void NameResolutionPass::process(const Node& ast)

--- a/src/arkscript/Formatter.cpp
+++ b/src/arkscript/Formatter.cpp
@@ -259,6 +259,15 @@ std::string Formatter::formatFunction(const Node& node, const std::size_t indent
 
     std::string formatted_args;
 
+    if (!args_node.comment().empty())
+    {
+        formatted_args += "\n";
+        formatted_args += formatComment(args_node.comment(), indent + 1);
+        formatted_args += prefix(indent + 1);
+    }
+    else
+        formatted_args += " ";
+
     if (args_node.isListLike())
     {
         bool comment_in_args = false;
@@ -274,14 +283,14 @@ std::string Formatter::formatFunction(const Node& node, const std::size_t indent
                 args += comment_in_args ? '\n' : ' ';
         }
 
-        formatted_args = fmt::format("({}{})", (comment_in_args ? "\n" : ""), args);
+        formatted_args += fmt::format("({}{})", (comment_in_args ? "\n" : ""), args);
     }
     else
-        formatted_args = format(args_node, indent, false);
+        formatted_args += format(args_node, indent, false);
 
-    if (!shouldSplitOnNewline(body_node))
-        return fmt::format("(fun {} {})", formatted_args, format(body_node, indent + 1, false));
-    return fmt::format("(fun {}\n{})", formatted_args, format(body_node, indent + 1, true));
+    if (!shouldSplitOnNewline(body_node) && args_node.comment().empty())
+        return fmt::format("(fun{} {})", formatted_args, format(body_node, indent + 1, false));
+    return fmt::format("(fun{}\n{})", formatted_args, format(body_node, indent + 1, true));
 }
 
 std::string Formatter::formatVariable(const Node& node, const std::size_t indent)

--- a/src/arkscript/Formatter.cpp
+++ b/src/arkscript/Formatter.cpp
@@ -12,11 +12,11 @@ using namespace Ark;
 using namespace Ark::internal;
 
 Formatter::Formatter(bool dry_run) :
-    m_dry_run(dry_run), m_parser(/* debug= */ 0, /* interpret= */ false)
+    m_dry_run(dry_run), m_parser(/* debug= */ 0, /* interpret= */ false), m_updated(false)
 {}
 
 Formatter::Formatter(std::string filename, const bool dry_run) :
-    m_filename(std::move(filename)), m_dry_run(dry_run), m_parser(/* debug= */ 0, /* interpret= */ false)
+    m_filename(std::move(filename)), m_dry_run(dry_run), m_parser(/* debug= */ 0, /* interpret= */ false), m_updated(false)
 {}
 
 void Formatter::run()
@@ -27,6 +27,8 @@ void Formatter::run()
         m_parser.process(m_filename, code);
         processAst(m_parser.ast());
         warnIfCommentsWereRemoved(code, ARK_NO_NAME_FILE);
+
+        m_updated = code != m_output;
     }
     catch (const CodeError& e)
     {
@@ -41,6 +43,8 @@ void Formatter::runWithString(const std::string& code)
         m_parser.process(ARK_NO_NAME_FILE, code);
         processAst(m_parser.ast());
         warnIfCommentsWereRemoved(code, ARK_NO_NAME_FILE);
+
+        m_updated = code != m_output;
     }
     catch (const CodeError& e)
     {
@@ -51,6 +55,11 @@ void Formatter::runWithString(const std::string& code)
 const std::string& Formatter::output() const
 {
     return m_output;
+}
+
+bool Formatter::codeModified() const
+{
+    return m_updated;
 }
 
 void Formatter::processAst(const Node& ast)

--- a/src/arkscript/REPL/Repl.cpp
+++ b/src/arkscript/REPL/Repl.cpp
@@ -19,22 +19,22 @@ namespace Ark
         m_old_ip(0), m_lib_env(lib_env),
         m_state(m_lib_env), m_vm(m_state), m_has_init_vm(false)
     {
-        m_keywords.reserve(keywords.size() + listInstructions.size() + operators.size() + Builtins::builtins.size());
+        m_keywords.reserve(keywords.size() + listInstructions.size() + Language::operators.size() + Builtins::builtins.size());
         for (auto keyword : keywords)
             m_keywords.emplace_back(keyword);
         for (auto inst : listInstructions)
             m_keywords.emplace_back(inst);
-        for (auto op : operators)
+        for (auto op : Language::operators)
             m_keywords.emplace_back(op);
         for (const auto& builtin : std::ranges::views::keys(Builtins::builtins))
             m_keywords.push_back(builtin);
 
-        m_words_colors.reserve(keywords.size() + listInstructions.size() + operators.size() + Builtins::builtins.size() + 2);
+        m_words_colors.reserve(keywords.size() + listInstructions.size() + Language::operators.size() + Builtins::builtins.size() + 2);
         for (auto keyword : keywords)
             m_words_colors.emplace_back(keyword, Replxx::Color::BRIGHTRED);
         for (auto inst : listInstructions)
             m_words_colors.emplace_back(inst, Replxx::Color::GREEN);
-        for (auto op : operators)
+        for (auto op : Language::operators)
         {
             auto safe_op = std::string(op);
             if (const auto it = safe_op.find_first_of(R"(-+=/*<>[]()?")"); it != std::string::npos)

--- a/tests/arkscript/macro-tests.ark
+++ b/tests/arkscript/macro-tests.ark
@@ -3,11 +3,11 @@
 ($ suffix-dup (sym x) {
     ($if (> x 1)
         (suffix-dup sym (- x 1)))
-    (symcat sym x)})
+    ($symcat sym x)})
 (let magic_func (fun ((suffix-dup a 3)) (- a1 a2 a3)))
 
 ($ partial (func ...defargs) {
-    ($ bloc (suffix-dup a (- (argcount func) (len defargs))))
+    ($ bloc (suffix-dup a (- ($argcount func) (len defargs))))
     (fun (bloc) (func ...defargs bloc))
     ($undef bloc)})
 
@@ -113,7 +113,7 @@
 
     (test:case "define variable with a macro adding a suffix" {
         ($ nice_value 12)
-        ($ define (prefix suffix value) (let (symcat prefix suffix) value))
+        ($ define (prefix suffix value) (let ($symcat prefix suffix) value))
 
         (define a 1 2)
         (test:eq a1 2)
@@ -126,11 +126,11 @@
 
     (test:case "partial functions" {
         (test:eq (magic_func 1 2 3) (- 1 2 3))
-        (test:eq (argcount test_func) 3)
-        (test:eq (argcount test_func1) 2)
-        (test:eq (argcount test_func1_2) 1)
-        (test:eq (argcount (fun () ())) 0)
-        (test:eq (argcount (fun (a) ())) 1)
-        (test:eq (argcount (fun (a b g h u t) ())) 6)
+        (test:eq ($argcount test_func) 3)
+        (test:eq ($argcount test_func1) 2)
+        (test:eq ($argcount test_func1_2) 1)
+        (test:eq ($argcount (fun () ())) 0)
+        (test:eq ($argcount (fun (a) ())) 1)
+        (test:eq ($argcount (fun (a b g h u t) ())) 6)
         (test:eq (test_func 1 2 3) (test_func1 2 3))
         (test:eq (test_func 1 2 3) (test_func1_2 3)) })})

--- a/tests/errors/compiler/invalid_let.ark
+++ b/tests/errors/compiler/invalid_let.ark
@@ -1,5 +1,5 @@
 ($ partial (func ...defargs) {
-    ($ bloc (suffix-dup a (- (argcount func) (len defargs))))
+    ($ bloc (suffix-dup a (- ($argcount func) (len defargs))))
 })
 
 (let test_func (fun (a b c) (* a b c)))

--- a/tests/errors/macros/argcount_unknown_arg.ark
+++ b/tests/errors/macros/argcount_unknown_arg.ark
@@ -1,10 +1,10 @@
 ($ suffix-dup (sym x) {
     ($if (> x 1)
         (suffix-dup sym (- x 1)))
-    (symcat sym x)})
+    ($symcat sym x)})
 
 ($ partial (func ...defargs) {
-    ($ bloc (suffix-dup a (- (argcount func) (len defargs))))
+    ($ bloc (suffix-dup a (- ($argcount func) (len defargs))))
     (fun (bloc) (func ...defargs bloc))
     ($undef bloc)})
 

--- a/tests/errors/macros/argcount_unknown_arg.expected
+++ b/tests/errors/macros/argcount_unknown_arg.expected
@@ -6,4 +6,4 @@ At test_func1!2 @ 13:41
    13 | (let test_func1_2 (partial test_func1!2))
       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    14 |
-        When expanding `argcount', expected a known function name, got unbound variable test_func1!2
+        When expanding `$argcount', expected a known function name, got unbound variable test_func1!2

--- a/tests/errors/macros/max_unification_depth.ark
+++ b/tests/errors/macros/max_unification_depth.ark
@@ -2,7 +2,7 @@
     ($if (+ x 1)
         est_func
         ($ p (a b c) (* a b c)))
-    (symcat sym x)})
+    ($symcat sym x)})
 
 ($ partial (func ...defargs) {
     ($ bloc (suffix-dup a (len defargs)))

--- a/tests/unittests/VMSuite.cpp
+++ b/tests/unittests/VMSuite.cpp
@@ -87,6 +87,32 @@ ut::suite<"VM"> vm_suite = [] {
         };
     };
 
+    "[reset the VM and use it to run code again]"_test = [] {
+        Ark::State state;
+
+        should("compile the string without any error") = [&] {
+            expect(mut(state).doString("(let foo (fun (a b) (+ a b))) (let t (time))"));
+        };
+
+        Ark::VM vm(state);
+        double timestamp = 0.0;
+        should("return exit code 0") = [&] {
+            expect(mut(vm).run() == 0_i);
+            timestamp = vm["t"].number();
+        };
+
+        should("have symbol foo registered") = [&] {
+            const auto func = mut(vm)["foo"];
+            expect(func.isFunction());
+        };
+
+        should("reset VM by running code again") = [&] {
+            expect(mut(vm).run() == 0_i);
+            const double new_time = vm["t"].number();
+            expect(that % timestamp < new_time);
+        };
+    };
+
     "[load cpp function and call it from arkscript]"_test = [] {
         Ark::State state;
         state.loadFunction("my_function", my_function);

--- a/tests/unittests/resources/ASTSuite/macros.ark
+++ b/tests/unittests/resources/ASTSuite/macros.ark
@@ -1,10 +1,10 @@
 ($ suffix-dup (sym x) {
     ($if (> x 1)
         (suffix-dup sym (- x 1)))
-    (symcat sym x)})
+    ($symcat sym x)})
 
 ($ partial (func ...defargs) {
-    ($ bloc (suffix-dup a (- (argcount func) (len defargs))))
+    ($ bloc (suffix-dup a (- ($argcount func) (len defargs))))
     (fun (bloc) (func ...defargs bloc))
     ($undef bloc)})
 
@@ -12,8 +12,8 @@
 (let test_func1 (partial test_func 1))
 
 (print "Generated partial functions for test_func (a b c) => (* a b c)")
-(print "Expected arguments for test_func:  " (argcount test_func) ", expected " 3)
-(print "Expected arguments for test_func1: " (argcount test_func1) ", expected " 2)
+(print "Expected arguments for test_func:  " ($argcount test_func) ", expected " 3)
+(print "Expected arguments for test_func1: " ($argcount test_func1) ", expected " 2)
 (print "Calling them: " (test_func 1 2 3) " " (test_func1 2 3))
 
 ($ foo (a b) (+ a b))

--- a/tests/unittests/resources/FormatterSuite/functions.expected
+++ b/tests/unittests/resources/FormatterSuite/functions.expected
@@ -8,7 +8,9 @@
   (fun () {
     hello })
   maybe)
-(fun (
+(fun
+  # test
+  (
   # a
   a
   b


### PR DESCRIPTION
## Description

- Comments can be included between `fun` and the argument block.
- Renamed `argcount` to `$argcount` and `symcat` to `$symcat` for uniformity

Closes #488 

## Checklist

- [x] I have read the [Contributor guide](CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation if needed
- [ ] I have added tests that prove my fix/feature is working
- [x] New and existing tests pass locally with my changes
