### PR TITLE
Fix/exported symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
 - `list:setAt` can work with negative indexes, and is now bound checked
 - re-enabled the AST optimizer, only used for the main `arkscript` executable (not enabled when embedding arkscript, so that one can grab variables from the VM)
 - loops have their own scope: variables created inside a loop won't leak outside it
+- upgraded fmtlib to 11.1.3-13
 
 ### Removed
 - removed unused `NodeType::Closure`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,8 @@ if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR APPLE)
             -fvisibility=hidden
             -fno-semantic-interposition
     )
+    # set fmtlib visibility to default
+    target_compile_definitions(ArkReactor PUBLIC FMT_SHARED)
 
     if (APPLE)
         # The standard SSH libraries are depreciate on APPLE.
@@ -114,7 +116,8 @@ elseif (MSVC)
             /wd4267   # disable warning about data loss (size_t -> int)
             /wd4244   # disable warning about data loss (size_t -> char)
             /wd4505   # disable warning about unused static function was deleted
-            /wd4068)  # disable warnings about unknown pragmas.
+            /wd4068   # disable warnings about unknown pragmas.
+            /utf-8)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:8000000")  # set stack size to 8MB
 endif ()
 

--- a/include/Ark/Compiler/AST/Optimizer.hpp
+++ b/include/Ark/Compiler/AST/Optimizer.hpp
@@ -16,6 +16,7 @@
 #include <unordered_map>
 #include <string>
 
+#include <Ark/Platform.hpp>
 #include <Ark/Compiler/Pass.hpp>
 #include <Ark/Compiler/AST/Node.hpp>
 
@@ -25,7 +26,7 @@ namespace Ark::internal
      * @brief The ArkScript AST optimizer
      *
      */
-    class Optimizer final : public Pass
+    class ARK_API Optimizer final : public Pass
     {
     public:
         /**

--- a/include/Ark/Compiler/Macros/Processor.hpp
+++ b/include/Ark/Compiler/Macros/Processor.hpp
@@ -12,6 +12,7 @@
 #ifndef COMPILER_MACROS_PROCESSOR_HPP
 #define COMPILER_MACROS_PROCESSOR_HPP
 
+#include <Ark/Platform.hpp>
 #include <Ark/Compiler/AST/Node.hpp>
 #include <Ark/Compiler/Macros/MacroScope.hpp>
 #include <Ark/Compiler/Pass.hpp>
@@ -28,7 +29,7 @@ namespace Ark::internal
      * @brief The class handling the macros definitions and calls, given an AST
      *
      */
-    class MacroProcessor final : public Pass
+    class ARK_API MacroProcessor final : public Pass
     {
     public:
         /**

--- a/include/Ark/Compiler/NameResolution/NameResolutionPass.hpp
+++ b/include/Ark/Compiler/NameResolution/NameResolutionPass.hpp
@@ -16,12 +16,13 @@
 #include <string>
 #include <unordered_set>
 
+#include <Ark/Platform.hpp>
 #include <Ark/Compiler/Pass.hpp>
 #include <Ark/Compiler/NameResolution/ScopeResolver.hpp>
 
 namespace Ark::internal
 {
-    class NameResolutionPass final : public Pass
+    class ARK_API NameResolutionPass final : public Pass
     {
     public:
         /**

--- a/include/Ark/Compiler/NameResolution/StaticScope.hpp
+++ b/include/Ark/Compiler/NameResolution/StaticScope.hpp
@@ -49,6 +49,13 @@ namespace Ark::internal
     public:
         virtual ~StaticScope() = default;
 
+        StaticScope() = default;
+
+        StaticScope(const StaticScope&) = delete;
+        StaticScope& operator=(const StaticScope&) = delete;
+        StaticScope(StaticScope&&) = default;
+        StaticScope& operator=(StaticScope&&) = default;
+
         /**
          * @brief Add a Declaration to the scope, given a mutability status
          * @param name
@@ -94,6 +101,11 @@ namespace Ark::internal
     {
     public:
         NamespaceScope(std::string name, bool with_prefix, bool is_glob, const std::vector<std::string>& symbols);
+
+        NamespaceScope(const NamespaceScope&) = delete;
+        NamespaceScope& operator=(const NamespaceScope&) = delete;
+        NamespaceScope(NamespaceScope&&) = default;
+        NamespaceScope& operator=(NamespaceScope&&) = default;
 
         /**
          * @brief Add a Declaration to the scope, given a mutability status

--- a/include/Ark/Compiler/Package/ImportSolver.hpp
+++ b/include/Ark/Compiler/Package/ImportSolver.hpp
@@ -18,6 +18,7 @@
 #include <filesystem>
 #include <unordered_map>
 
+#include <Ark/Platform.hpp>
 #include <Ark/Compiler/Pass.hpp>
 #include <Ark/Compiler/AST/Node.hpp>
 #include <Ark/Compiler/AST/Import.hpp>
@@ -25,7 +26,7 @@
 
 namespace Ark::internal
 {
-    class ImportSolver final : public Pass
+    class ARK_API ImportSolver final : public Pass
     {
     public:
         /**

--- a/include/Ark/Compiler/Pass.hpp
+++ b/include/Ark/Compiler/Pass.hpp
@@ -11,6 +11,7 @@
 #ifndef ARK_COMPILER_PASS_HPP
 #define ARK_COMPILER_PASS_HPP
 
+#include <Ark/Platform.hpp>
 #include <Ark/Compiler/AST/Node.hpp>
 #include <Ark/Logger.hpp>
 
@@ -19,7 +20,7 @@ namespace Ark::internal
     /**
      * @brief An interface to describe compiler passes
      */
-    class Pass
+    class ARK_API Pass
     {
     public:
         /**


### PR DESCRIPTION
## Description

Fix exported symbols by using `ARK_API` after 75d4a3743395e926b89a91a1e83f881b350fe9f8 enabled visibility=hidden and no semantic interposition.

## Checklist

- [x] I have read the [Contributor guide](CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation if needed
- [ ] I have added tests that prove my fix/feature is working
- [x] New and existing tests pass locally with my changes
