### PR TITLE
feat(builtins): turning random into a builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - compile time argument count check for `and` and `or`
 - basic dead code elimination in the AST optimizer
 - new operator `@@` to get elements in list of lists / list of strings
+- new builtin `random`, returning a random number between INT_MIN and INT_MAX, or in a custom range
 
 ### Changed
 - instructions are on 4 bytes: 1 byte for the instruction, 1 byte of padding, 2 bytes for an immediate argument

--- a/README.md
+++ b/README.md
@@ -53,10 +53,7 @@ Also, it has:
 ## More or less game
 
 ```clojure
-(import std.random)
-(import std.Math)
-
-(let number (mod (math:abs (random)) 10000))
+(let number (random 0 10000))
 
 (let game (fun () {
   (let impl (fun (tries) {

--- a/examples/games/more-or-less.ark
+++ b/examples/games/more-or-less.ark
@@ -1,7 +1,4 @@
-(import random)
-(import std.Math)
-
-(let number (mod (math:abs (random)) 10000))
+(let number (random 0 10000))
 
 (let game (fun () {
   (let impl (fun (tries) {

--- a/include/Ark/Builtins/Builtins.hpp
+++ b/include/Ark/Builtins/Builtins.hpp
@@ -108,6 +108,8 @@ namespace Ark::internal::Builtins
         Value acosh_(std::vector<Value>& n, VM* vm);  // math:acosh, 1 argument
         Value asinh_(std::vector<Value>& n, VM* vm);  // math:asinh, 1 argument
         Value atanh_(std::vector<Value>& n, VM* vm);  // math:atanh, 1 argument
+
+        Value random(std::vector<Value>& n, VM* vm);  // random, 0-2 args
     }
 
     namespace Async

--- a/src/arkreactor/Builtins/Builtins.cpp
+++ b/src/arkreactor/Builtins/Builtins.cpp
@@ -87,6 +87,7 @@ namespace Ark::internal::Builtins
         { "math:acosh", Value(Mathematics::acosh_) },
         { "math:asinh", Value(Mathematics::asinh_) },
         { "math:atanh", Value(Mathematics::atanh_) },
+        { "random", Value(Mathematics::random) },
 
         // Async
         { "async", Value(Async::async) },

--- a/src/arkreactor/Builtins/Mathematics.cpp
+++ b/src/arkreactor/Builtins/Mathematics.cpp
@@ -1,6 +1,7 @@
 #define _USE_MATH_DEFINES
 #include <cmath>
 #include <fmt/core.h>
+#include <random>
 
 #include <Ark/Builtins/Builtins.hpp>
 
@@ -384,5 +385,40 @@ namespace Ark::internal::Builtins::Mathematics
                 n);
 
         return Value(std::atanh(n[0].number()));
+    }
+
+    /**
+     * @name random
+     * @brief Compute a random number in [-2147483648, 2147483647] or in a custom range passed to the function
+     * @param min optional inclusive lower bound
+     * @param max optional inclusive upper bound. Must be present if `min` is passed
+     * =begin
+     * (print (random))  # a number in [-2147483648, 2147483647]
+     * (print (random 0 10))  # a number between 0 and 10
+     * =end
+     * @author https://github.com/SuperFola
+     */
+    Value random(std::vector<Value>& n, VM* vm [[maybe_unused]])
+    {
+        static std::mt19937 gen { std::random_device()() };
+
+        if (n.size() == 2 && !types::check(n, ValueType::Number, ValueType::Number))
+            types::generateError(
+                "random",
+                { { types::Contract {
+                    { types::Typedef("min", ValueType::Number), types::Typedef("max", ValueType::Number) } } } },
+                n);
+
+        if (n.size() == 2)
+        {
+            const auto inclusive_min = static_cast<int>(n[0].number()),
+                       inclusive_max = static_cast<int>(n[1].number());
+
+            std::uniform_int_distribution<> distrib(inclusive_min, inclusive_max);
+            return Value(distrib(gen));
+        }
+
+        const auto x = static_cast<int>(gen());
+        return Value(x);
     }
 }

--- a/tests/fuzzing/arkscript.dict
+++ b/tests/fuzzing/arkscript.dict
@@ -80,3 +80,4 @@
 "math:arccos"
 "math:arcsin"
 "math:arctan"
+"random"

--- a/tests/fuzzing/corpus-cmin-tmin/examples_games_more-or-less.ark
+++ b/tests/fuzzing/corpus-cmin-tmin/examples_games_more-or-less.ark
@@ -1,7 +1,4 @@
-(import random)
-(import std.Math)
-
-(let number (mod (math:abs (random)) 10000))
+(let number (random 0 10000))
 
 (let game (fun () {
   (let impl (fun (tries) {

--- a/tests/fuzzing/corpus-cmin/examples_games_more-or-less.ark
+++ b/tests/fuzzing/corpus-cmin/examples_games_more-or-less.ark
@@ -1,7 +1,4 @@
-(import random)
-(import std.Math)
-
-(let number (mod (math:abs (random)) 10000))
+(let number (random 0 10000))
 
 (let game (fun () {
   (let impl (fun (tries) {

--- a/tests/fuzzing/corpus/examples_games_more-or-less.ark
+++ b/tests/fuzzing/corpus/examples_games_more-or-less.ark
@@ -1,7 +1,4 @@
-(import random)
-(import std.Math)
-
-(let number (mod (math:abs (random)) 10000))
+(let number (random 0 10000))
 
 (let game (fun () {
   (let impl (fun (tries) {

--- a/tests/unittests/resources/LangSuite/builtins-tests.ark
+++ b/tests/unittests/resources/LangSuite/builtins-tests.ark
@@ -1,4 +1,5 @@
 (import std.Testing)
+(import std.List)
 
 (let foo (fun () ()))
 (let closure (fun (&foo) ()))
@@ -29,6 +30,15 @@
     (let old (time))
     (sys:sleep 1)
     (test:expect (< old (time)))
+
+    (mut rands [])
+    (mut i 0)
+    (while (< i 100) {
+      (append! rands (random 0 10))
+      (set i (+ 1 i)) })
+    (test:expect
+      (not (list:any rands (fun (e) (or (< e 0) (> e 10)))))
+      "should not find any number outside the given range")
 
     # no need to test the math functions since they're 1:1 binding of C++ functions and were carefully checked
     # before writing this comment, to ensure we aren't binding math:sin to the C++ tan function


### PR DESCRIPTION
## Description

`random` is a pretty useful tool, having it in a module didn't make sense. It is now a builtin, that can take an optional range. 

## Checklist

- [x] I have read the [Contributor guide](CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation if needed
- [x] I have added tests that prove my fix/feature is working
- [x] New and existing tests pass locally with my changes
