### PR TITLE
Fix issue 544

### DIFF
--- a/include/Ark/VM/VM.inl
+++ b/include/Ark/VM/VM.inl
@@ -21,9 +21,12 @@ Value VM::call(const std::string& name, Args&&... args)
     push(Value(ValueType::InstPtr, static_cast<internal::PageAddr_t>(0)), context);
 
     // convert and push arguments
-    std::vector<Value> fnargs { { Value(std::forward<Args>(args))... } };
-    for (auto&& arg : fnargs | std::views::reverse)
-        push(arg, context);
+    if (sizeof...(args) > 0)
+    {
+        std::vector<Value> fnargs { { Value(std::forward<Args>(args))... } };
+        for (auto&& arg : fnargs | std::views::reverse)
+            push(arg, context);
+    }
 
     // find function object and push it if it's a pageaddr/closure
     if (const auto dist = std::distance(m_state.m_symbols.begin(), it); std::cmp_less(dist, std::numeric_limits<uint16_t>::max()))

--- a/tests/unittests/Suites/EmbeddingSuite.cpp
+++ b/tests/unittests/Suites/EmbeddingSuite.cpp
@@ -63,6 +63,30 @@ Ark::UserType::ControlFuncs* get_cfs()
 ut::suite<"Embedding"> embedding_suite = [] {
     using namespace ut;
 
+    "[run string and call arkscript function from cpp without args]"_test = [] {
+        Ark::State state;
+
+        should("compile the string without any error") = [&] {
+            expect(mut(state).doString("(let foo (fun () 4))"));
+        };
+
+        Ark::VM vm(state);
+        should("return exit code 0") = [&] {
+            expect(mut(vm).run() == 0_i);
+        };
+
+        should("have symbol foo registered") = [&] {
+            const auto func = mut(vm)["foo"];
+            expect(func.isFunction());
+        };
+
+        should("(foo) have a value of 4") = [&] {
+            const auto value = mut(vm).call("foo");
+            expect(value.valueType() == Ark::ValueType::Number);
+            expect(value.number() == 4.0_d);
+        };
+    };
+
     "[run string and call arkscript function from cpp]"_test = [] {
         Ark::State state;
 


### PR DESCRIPTION
## Description

Calling an ArkScript function from C++ code without argument shouldn't create a bogus vector with a Value(Undefined, 0) inside.

Closes #544 

## Checklist

- [x] I have read the [Contributor guide](CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation if needed
- [x] I have added tests that prove my fix/feature is working
- [x] New and existing tests pass locally with my changes
