### PR TITLE
refactor: move Value::ProcType to std::function

### DIFF
--- a/include/Ark/VM/State.hpp
+++ b/include/Ark/VM/State.hpp
@@ -18,6 +18,7 @@
 #include <Ark/Constants.hpp>
 
 #include <Ark/VM/Value.hpp>
+#include <Ark/VM/Value/Procedure.hpp>
 #include <Ark/Compiler/Common.hpp>
 #include <Ark/Exceptions.hpp>
 #include <Ark/Compiler/IntermediateRepresentation/InstLoc.hpp>
@@ -82,7 +83,7 @@ namespace Ark
          * @param name the name of the function in ArkScript
          * @param function the code of the function
          */
-        void loadFunction(const std::string& name, Value::ProcType function) noexcept;
+        void loadFunction(const std::string& name, Procedure::CallbackType function) noexcept;
 
         /**
          * @brief Set the script arguments in sys:args

--- a/include/Ark/VM/State.hpp
+++ b/include/Ark/VM/State.hpp
@@ -83,7 +83,7 @@ namespace Ark
          * @param name the name of the function in ArkScript
          * @param function the code of the function
          */
-        void loadFunction(const std::string& name, Procedure::CallbackType function) noexcept;
+        void loadFunction(const std::string& name, Procedure::CallbackType&& function) noexcept;
 
         /**
          * @brief Set the script arguments in sys:args

--- a/include/Ark/VM/Value.hpp
+++ b/include/Ark/VM/Value.hpp
@@ -19,6 +19,7 @@
 
 #include <Ark/VM/Value/Closure.hpp>
 #include <Ark/VM/Value/UserType.hpp>
+#include <Ark/VM/Value/Procedure.hpp>
 #include <Ark/Platform.hpp>
 
 namespace Ark
@@ -68,14 +69,13 @@ namespace Ark
     class ARK_API Value
     {
     public:
-        using ProcType = Value (*)(std::vector<Value>&, VM*);
         using Iterator = std::vector<Value>::iterator;
 
         using Value_t = std::variant<
             double,                //  8 bytes
             std::string,           // 32 bytes
             internal::PageAddr_t,  //  2 bytes
-            ProcType,              //  8 bytes
+            Procedure,             // 32 bytes
             internal::Closure,     // 24 bytes
             UserType,              // 24 bytes
             std::vector<Value>,    // 24 bytes
@@ -114,7 +114,7 @@ namespace Ark
         explicit Value(double value) noexcept;
         explicit Value(const std::string& value) noexcept;
         explicit Value(internal::PageAddr_t value) noexcept;
-        explicit Value(ProcType value) noexcept;
+        explicit Value(Procedure&& value) noexcept;
         explicit Value(std::vector<Value>&& value) noexcept;
         explicit Value(internal::Closure&& value) noexcept;
         explicit Value(UserType&& value) noexcept;
@@ -170,7 +170,7 @@ namespace Ark
         [[nodiscard]] constexpr uint8_t typeNum() const noexcept { return static_cast<uint8_t>(m_type); }
 
         [[nodiscard]] internal::PageAddr_t pageAddr() const { return std::get<internal::PageAddr_t>(m_value); }
-        [[nodiscard]] const ProcType& proc() const { return std::get<ProcType>(m_value); }
+        [[nodiscard]] const Procedure& proc() const { return std::get<Procedure>(m_value); }
         [[nodiscard]] const internal::Closure& closure() const { return std::get<internal::Closure>(m_value); }
         [[nodiscard]] internal::Closure& refClosure() { return std::get<internal::Closure>(m_value); }
     };

--- a/include/Ark/VM/Value.hpp
+++ b/include/Ark/VM/Value.hpp
@@ -113,6 +113,7 @@ namespace Ark
         explicit Value(int value) noexcept;
         explicit Value(double value) noexcept;
         explicit Value(const std::string& value) noexcept;
+        explicit Value(const char* value) noexcept;
         explicit Value(internal::PageAddr_t value) noexcept;
         explicit Value(Procedure&& value) noexcept;
         explicit Value(std::vector<Value>&& value) noexcept;

--- a/include/Ark/VM/Value/Procedure.hpp
+++ b/include/Ark/VM/Value/Procedure.hpp
@@ -1,7 +1,7 @@
 /**
  * @file Procedure.hpp
  * @author Justin Andreas Lacoste (me@justin.cx)
- * @brief Wrapper object user-defined functions
+ * @brief Wrapper object for user-defined functions
  * @date 2025-06-09
  *
  * @copyright Copyright (c) 2025
@@ -12,7 +12,6 @@
 #define ARK_VM_PROCEDURE_HPP
 
 #include <functional>
-#include <type_traits>
 #include <vector>
 
 namespace Ark
@@ -29,18 +28,33 @@ namespace Ark
         using PointerType = Value (*)(std::vector<Value>&, VM*);
         using CallbackType = std::function<Value(std::vector<Value>&, VM*)>;
 
+        ///
+        /// Due to clang (sometimes) rejecting forward declared types
+        /// in templates (`Value` causes issues), we have to implement
+        /// the constructor for the actual `CallbackType` using SFINAE
+        /// and a templated constructor, such that when clang
+        /// encounters the constructor, it knows the actual
+        /// declaration of `Value`.
+        ///
         /**
-         * @brief Create new Procedure from a plain C-style function pointer taking std::vector<Value>& and VM*.
-         *
-         * @param functor the function to store
+         * @brief Create a new procedure.
          */
-        template <typename T,
-                  typename = std::enable_if_t<std::is_pointer_v<T> && std::is_convertible_v<T, PointerType>>>
-        Procedure(T functor) noexcept :
-            m_procedure(functor) {}
+        template <typename T>
+        explicit Procedure(T&& cb)
+        {
+            m_procedure = cb;
+        }
 
-        Procedure(const CallbackType&) noexcept;
-        Procedure(CallbackType&&) noexcept;
+        /**
+         * @brief Create a new procedure from a stateless C function pointer.
+         */
+        Procedure(PointerType c_ptr);
+
+        Procedure(const Procedure&);
+        Procedure(Procedure&&);
+
+        Procedure& operator=(const Procedure& other);
+        Procedure& operator=(Procedure&& other);
 
         Value operator()(std::vector<Value>&, VM*) const;
 

--- a/include/Ark/VM/Value/Procedure.hpp
+++ b/include/Ark/VM/Value/Procedure.hpp
@@ -1,0 +1,55 @@
+/**
+ * @file Procedure.hpp
+ * @author Justin Andreas Lacoste (me@justin.cx)
+ * @brief Wrapper object user-defined functions
+ * @date 2025-06-09
+ *
+ * @copyright Copyright (c) 2025
+ *
+ */
+
+#ifndef ARK_VM_PROCEDURE_HPP
+#define ARK_VM_PROCEDURE_HPP
+
+#include <functional>
+#include <type_traits>
+#include <vector>
+
+namespace Ark
+{
+    class Value;
+    class VM;
+
+    /**
+     * @brief Storage class to hold custom functions
+     */
+    class ARK_API Procedure
+    {
+    public:
+        using PointerType = Value (*)(std::vector<Value>&, VM*);
+        using CallbackType = std::function<Value(std::vector<Value>&, VM*)>;
+
+        /**
+         * @brief Create new Procedure from a plain C-style function pointer taking std::vector<Value>& and VM*.
+         *
+         * @param functor the function to store
+         */
+        template <typename T,
+                  typename = std::enable_if_t<std::is_pointer_v<T> && std::is_convertible_v<T, PointerType>>>
+        Procedure(T functor) noexcept :
+            m_procedure(functor) {}
+
+        Procedure(const CallbackType&) noexcept;
+        Procedure(CallbackType&&) noexcept;
+
+        Value operator()(std::vector<Value>&, VM*) const;
+
+        bool operator<(const Procedure& other) const noexcept;
+        bool operator==(const Procedure& other) const noexcept;
+
+    private:
+        CallbackType m_procedure;
+    };
+}
+
+#endif

--- a/include/Ark/VM/Value/Procedure.hpp
+++ b/include/Ark/VM/Value/Procedure.hpp
@@ -40,21 +40,15 @@ namespace Ark
          * @brief Create a new procedure.
          */
         template <typename T>
-        explicit Procedure(T&& cb)
+        Procedure(T&& cb) :
+            m_procedure(cb)
         {
-            m_procedure = cb;
         }
 
         /**
          * @brief Create a new procedure from a stateless C function pointer.
          */
         Procedure(PointerType c_ptr);
-
-        Procedure(const Procedure&);
-        Procedure(Procedure&&);
-
-        Procedure& operator=(const Procedure& other);
-        Procedure& operator=(Procedure&& other);
 
         Value operator()(std::vector<Value>&, VM*) const;
 

--- a/src/arkreactor/VM/State.cpp
+++ b/src/arkreactor/VM/State.cpp
@@ -117,9 +117,9 @@ namespace Ark
         return feed(welder.bytecode());
     }
 
-    void State::loadFunction(const std::string& name, const Value::ProcType function) noexcept
+    void State::loadFunction(const std::string& name, const Procedure::CallbackType function) noexcept
     {
-        m_binded[name] = Value(function);
+        m_binded[name] = Value(Procedure(function));
     }
 
     void State::setArgs(const std::vector<std::string>& args) noexcept

--- a/src/arkreactor/VM/State.cpp
+++ b/src/arkreactor/VM/State.cpp
@@ -117,9 +117,9 @@ namespace Ark
         return feed(welder.bytecode());
     }
 
-    void State::loadFunction(const std::string& name, const Procedure::CallbackType function) noexcept
+    void State::loadFunction(const std::string& name, Procedure::CallbackType&& function) noexcept
     {
-        m_binded[name] = Value(Procedure(function));
+        m_binded[name] = Value(std::move(function));
     }
 
     void State::setArgs(const std::vector<std::string>& args) noexcept

--- a/src/arkreactor/VM/VM.cpp
+++ b/src/arkreactor/VM/VM.cpp
@@ -319,7 +319,7 @@ namespace Ark
                 // put it in the global frame, aka the first one
                 auto it = std::ranges::find(m_state.m_symbols, std::string(map[i].name));
                 if (it != m_state.m_symbols.end())
-                    context.locals[0].push_back(static_cast<uint16_t>(std::distance(m_state.m_symbols.begin(), it)), Value(map[i].value));
+                    context.locals[0].push_back(static_cast<uint16_t>(std::distance(m_state.m_symbols.begin(), it)), Value(Procedure(map[i].value)));
 
                 ++i;
             }
@@ -421,7 +421,7 @@ namespace Ark
                     if (it != m_state.m_symbols.end())
                         m_execution_contexts[0]->locals[0].push_back(
                             static_cast<uint16_t>(std::distance(m_state.m_symbols.begin(), it)),
-                            Value(map[i].value));
+                            Value(Procedure(map[i].value)));
 
                     ++i;
                 }

--- a/src/arkreactor/VM/VM.cpp
+++ b/src/arkreactor/VM/VM.cpp
@@ -319,7 +319,7 @@ namespace Ark
                 // put it in the global frame, aka the first one
                 auto it = std::ranges::find(m_state.m_symbols, std::string(map[i].name));
                 if (it != m_state.m_symbols.end())
-                    context.locals[0].push_back(static_cast<uint16_t>(std::distance(m_state.m_symbols.begin(), it)), Value(Procedure(map[i].value)));
+                    context.locals[0].push_back(static_cast<uint16_t>(std::distance(m_state.m_symbols.begin(), it)), Value(map[i].value));
 
                 ++i;
             }
@@ -421,7 +421,7 @@ namespace Ark
                     if (it != m_state.m_symbols.end())
                         m_execution_contexts[0]->locals[0].push_back(
                             static_cast<uint16_t>(std::distance(m_state.m_symbols.begin(), it)),
-                            Value(Procedure(map[i].value)));
+                            Value(map[i].value));
 
                     ++i;
                 }

--- a/src/arkreactor/VM/Value.cpp
+++ b/src/arkreactor/VM/Value.cpp
@@ -1,4 +1,5 @@
 #include <Ark/VM/Value.hpp>
+#include <Ark/VM/Value/Procedure.hpp>
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
@@ -34,7 +35,7 @@ namespace Ark
         m_type(ValueType::PageAddr), m_value(value)
     {}
 
-    Value::Value(Value::ProcType value) noexcept :
+    Value::Value(Procedure&& value) noexcept :
         m_type(ValueType::CProc), m_value(value)
     {}
 

--- a/src/arkreactor/VM/Value.cpp
+++ b/src/arkreactor/VM/Value.cpp
@@ -16,7 +16,7 @@ namespace Ark
         if (type == ValueType::List)
             m_value = std::vector<Value>();
         else if (type == ValueType::String)
-            m_value = "";
+            m_value = std::string();
     }
 
     Value::Value(const int value) noexcept :
@@ -29,6 +29,10 @@ namespace Ark
 
     Value::Value(const std::string& value) noexcept :
         m_type(ValueType::String), m_value(value)
+    {}
+
+    Value::Value(const char* value) noexcept :
+        m_type(ValueType::String), m_value(std::string(value))
     {}
 
     Value::Value(internal::PageAddr_t value) noexcept :

--- a/src/arkreactor/VM/Value.cpp
+++ b/src/arkreactor/VM/Value.cpp
@@ -36,7 +36,7 @@ namespace Ark
     {}
 
     Value::Value(Procedure&& value) noexcept :
-        m_type(ValueType::CProc), m_value(value)
+        m_type(ValueType::CProc), m_value(std::move(value))
     {}
 
     Value::Value(std::vector<Value>&& value) noexcept :

--- a/src/arkreactor/VM/Value/Procedure.cpp
+++ b/src/arkreactor/VM/Value/Procedure.cpp
@@ -1,0 +1,31 @@
+#include <Ark/VM/Value.hpp>
+#include <Ark/VM/Value/Procedure.hpp>
+
+namespace Ark
+{
+    Procedure::Procedure(const CallbackType& functor) noexcept :
+        m_procedure(functor)
+    {
+    }
+
+    Procedure::Procedure(CallbackType&& functor) noexcept :
+        m_procedure(functor)
+    {
+    }
+
+    Value Procedure::operator()(std::vector<Value>& args, VM* vm) const
+    {
+        return m_procedure(args, vm);
+    }
+
+    bool Procedure::operator<(const Procedure&) const noexcept
+    {
+        return false;
+    }
+
+    bool Procedure::operator==(const Procedure&) const noexcept
+    {
+        return false;
+    }
+
+};

--- a/src/arkreactor/VM/Value/Procedure.cpp
+++ b/src/arkreactor/VM/Value/Procedure.cpp
@@ -1,21 +1,38 @@
 #include <Ark/VM/Value.hpp>
 #include <Ark/VM/Value/Procedure.hpp>
 
+#include <utility>
+
 namespace Ark
 {
-    Procedure::Procedure(const CallbackType& functor) noexcept :
-        m_procedure(functor)
-    {
-    }
-
-    Procedure::Procedure(CallbackType&& functor) noexcept :
-        m_procedure(functor)
-    {
-    }
-
     Value Procedure::operator()(std::vector<Value>& args, VM* vm) const
     {
         return m_procedure(args, vm);
+    }
+
+    Procedure::Procedure(PointerType c_pointer)
+    {
+        m_procedure = c_pointer;
+    }
+
+    Procedure::Procedure(Procedure&& other) :
+        m_procedure(std::exchange(other.m_procedure, nullptr)) {}
+
+    Procedure::Procedure(const Procedure& other) :
+        m_procedure(other.m_procedure)
+    {
+    }
+
+    Procedure& Procedure::operator=(Procedure&& other)
+    {
+        m_procedure = std::move(other.m_procedure);
+        return *this;
+    }
+
+    Procedure& Procedure::operator=(const Procedure& other)
+    {
+        m_procedure = other.m_procedure;
+        return *this;
     }
 
     bool Procedure::operator<(const Procedure&) const noexcept
@@ -27,5 +44,4 @@ namespace Ark
     {
         return false;
     }
-
 };

--- a/src/arkreactor/VM/Value/Procedure.cpp
+++ b/src/arkreactor/VM/Value/Procedure.cpp
@@ -15,26 +15,6 @@ namespace Ark
         m_procedure = c_pointer;
     }
 
-    Procedure::Procedure(Procedure&& other) :
-        m_procedure(std::exchange(other.m_procedure, nullptr)) {}
-
-    Procedure::Procedure(const Procedure& other) :
-        m_procedure(other.m_procedure)
-    {
-    }
-
-    Procedure& Procedure::operator=(Procedure&& other)
-    {
-        m_procedure = std::move(other.m_procedure);
-        return *this;
-    }
-
-    Procedure& Procedure::operator=(const Procedure& other)
-    {
-        m_procedure = other.m_procedure;
-        return *this;
-    }
-
     bool Procedure::operator<(const Procedure&) const noexcept
     {
         return false;

--- a/src/arkscript/main.cpp
+++ b/src/arkscript/main.cpp
@@ -226,7 +226,7 @@ int main(int argc, char** argv)
                     sizeof(Ark::Value),
                     sizeof(Ark::Value::Value_t),
                     sizeof(Ark::ValueType),
-                    sizeof(Ark::Value::ProcType),
+                    sizeof(Ark::Procedure),
                     sizeof(Ark::internal::Closure),
                     sizeof(Ark::UserType),
                     // vm

--- a/tests/unittests/Suites/EmbeddingSuite.cpp
+++ b/tests/unittests/Suites/EmbeddingSuite.cpp
@@ -1,10 +1,12 @@
 #include <boost/ut.hpp>
 
 #include <Ark/Ark.hpp>
+#include <Ark/Literals.hpp>
 #include <vector>
 #include <iostream>
 
 using namespace boost;
+using namespace Ark::literals;
 
 Ark::Value my_function(std::vector<Ark::Value>& args, Ark::VM* vm [[maybe_unused]])
 {
@@ -139,6 +141,63 @@ ut::suite<"Embedding"> embedding_suite = [] {
             expect(mut(vm).run() == 0_i);
             const double new_time = vm["t"].number();
             expect(that % timestamp < new_time);
+        };
+    };
+
+    "[load cpp function with captured data]"_test = [] {
+        Ark::State state;
+
+        int capture = 42;
+        state.loadFunction("my_function", [=](std::vector<Ark::Value>& args, Ark::VM* /*vm*/) {
+            int solution = 0;
+            for (const Ark::Value& value : args)
+            {
+                solution += value.number();
+            }
+            return Ark::Value(capture + solution);
+        });
+
+        should("compile the string without any error") = [&] {
+            expect(mut(state).doString("(let bar (my_function 1 2 3 1))"));
+        };
+
+        Ark::VM vm(state);
+        should("return exit code 0") = [&] {
+            expect(mut(vm).run() == 0_i);
+        };
+
+        should("compute egg to 49") = [&] {
+            auto egg = mut(vm)["bar"];
+            expect(egg.valueType() == Ark::ValueType::Number);
+            expect(egg.number() == 49_i);
+        };
+    };
+
+    "[load cpp function with captured reference]"_test = [] {
+        Ark::State state;
+
+        std::string name = "";
+        state.loadFunction("my_function", [&name](std::vector<Ark::Value>& args, Ark::VM* /*vm*/) {
+            for (const Ark::Value& value : args)
+            {
+                name.append(value.string());
+            }
+            return Ark::Value();
+        });
+
+        should("compile the string without any error") = [&] {
+            expect(mut(state).doString(R"(
+                (my_function "Iron" " " "Man")
+            )"));
+        };
+
+        Ark::VM vm(state);
+        should("return exit code 0") = [&] {
+            expect(mut(vm).run() == 0_i);
+        };
+
+        should("have mutated the capture variable") = [&] {
+            expect(name == "Iron Man");
         };
     };
 

--- a/tests/unittests/Suites/EmbeddingSuite.cpp
+++ b/tests/unittests/Suites/EmbeddingSuite.cpp
@@ -148,7 +148,7 @@ ut::suite<"Embedding"> embedding_suite = [] {
         Ark::State state;
 
         int capture = 42;
-        state.loadFunction("my_function", [=](std::vector<Ark::Value>& args, Ark::VM* /*vm*/) {
+        state.loadFunction("my_function", [=](std::vector<Ark::Value>& args, [[maybe_unused]] Ark::VM* /*vm*/) {
             int solution = 0;
             for (const Ark::Value& value : args)
             {
@@ -177,7 +177,7 @@ ut::suite<"Embedding"> embedding_suite = [] {
         Ark::State state;
 
         std::string name = "";
-        state.loadFunction("my_function", [&name](std::vector<Ark::Value>& args, Ark::VM* /*vm*/) {
+        state.loadFunction("my_function", [&name](std::vector<Ark::Value>& args, [[maybe_unused]] Ark::VM* /*vm*/) {
             for (const Ark::Value& value : args)
             {
                 name.append(value.string());

--- a/tests/unittests/Suites/TypeCheckerSuite.cpp
+++ b/tests/unittests/Suites/TypeCheckerSuite.cpp
@@ -122,9 +122,9 @@ Input parse_input(const std::string& path)
                     break;
 
                 case Ark::ValueType::CProc:
-                    given_args.emplace_back([](std::vector<Ark::Value>&, Ark::VM*) -> Ark::Value {
+                    given_args.emplace_back(Ark::Procedure([](std::vector<Ark::Value>&, Ark::VM*) -> Ark::Value {
                         return Ark::Value(Ark::ValueType::Nil);
-                    });
+                    }));
                     break;
 
                 case Ark::ValueType::Nil:


### PR DESCRIPTION
## Description

As discussed in #548, this commit refactors `Value::ProcType` from a plain C-style function pointer `Value(*)(std::vector<Value>&, VM *)` into a wrapper class holding a `std::function<>`.

This enables lambda capture for `State::loadFunction`, improving flexibility. 

This PR also adds two unit tests to test the relevant behaviour.

## Checklist

- [x] I have read the [Contributor guide](CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation if needed
- [x] I have added tests that prove my fix/feature is working
- [x] New and existing tests pass locally with my changes
