### PR TITLE
Add MingW support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,10 @@ if (ARK_TESTS)
     add_executable(unittests ${SOURCES})
     target_include_directories(unittests PUBLIC ${ark_SOURCE_DIR}/tests/unittests)
 
+    if (MINGW)
+      target_link_options(unittests PRIVATE -static)
+    endif ()
+
     target_include_directories(unittests SYSTEM PUBLIC ${ark_SOURCE_DIR}/lib/dtl/dtl)
 
     add_subdirectory(${ark_SOURCE_DIR}/lib/ut)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,15 @@ if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR APPLE)
     # set fmtlib visibility to default
     target_compile_definitions(ArkReactor PUBLIC FMT_SHARED)
 
+    # Enable FMT_LIB_EXPORT on MingW, otherwise it will fail to compile.
+    if (MINGW)
+        target_compile_definitions(ArkReactor PUBLIC FMT_LIB_EXPORT)
+        # Add -static to linking flags for MingW, otherwise it will
+        # dynamically link to libgcc_s_seh-1.dll, libwinpthread-1.dll
+        # and libstdc++-6.dll
+        target_link_options(ArkReactor PRIVATE -static)
+    endif ()
+
     if (APPLE)
         # The standard SSH libraries are depreciate on APPLE.
         # Thus they currently generate a warning that we have to ignore for now.
@@ -282,6 +291,11 @@ if (ARK_BUILD_EXE)
 
     if (ARK_UNITY_BUILD)
         set_target_properties(arkscript PROPERTIES UNITY_BUILD ON UNITY_BUILD_MODE BATCH UNITY_BUILD_BATCH_SIZE 16)
+    endif ()
+
+    if (MINGW)
+      # Statically link the arkscript executable
+      target_link_options(arkscript PRIVATE -static)
     endif ()
 
     enable_lto(arkscript)

--- a/include/Ark/Compiler/AST/BaseParser.hpp
+++ b/include/Ark/Compiler/AST/BaseParser.hpp
@@ -84,7 +84,7 @@ namespace Ark::internal
          *
          * @return distance in characters from the beginning of the file to the cursor
          */
-        size_t getCount() { return std::distance(m_str.begin(), m_it); }
+        ssize_t getCount() { return std::distance(m_str.begin(), m_it); }
 
         /**
          *

--- a/include/Ark/Compiler/AST/BaseParser.hpp
+++ b/include/Ark/Compiler/AST/BaseParser.hpp
@@ -84,7 +84,7 @@ namespace Ark::internal
          *
          * @return distance in characters from the beginning of the file to the cursor
          */
-        long getCount() { return std::distance(m_str.begin(), m_it); }
+        size_t getCount() { return std::distance(m_str.begin(), m_it); }
 
         /**
          *

--- a/include/Ark/VM/Plugin.hpp
+++ b/include/Ark/VM/Plugin.hpp
@@ -94,7 +94,10 @@ namespace Ark::internal
             T funcptr;
 
 #if defined(ARK_OS_WINDOWS)
-            if (NULL == (funcptr = reinterpret_cast<T>(GetProcAddress(m_instance, procname.c_str()))))
+            // casting from FARPROC -> void* -> T is required on MingW
+            // target, immediate conversion from FARPROC -> T will fail.
+            void* pluginhandle = reinterpret_cast<void*>(GetProcAddress(m_instance, procname.c_str()));
+            if (NULL == (funcptr = reinterpret_cast<T>(pluginhandle)))
             {
                 throw std::system_error(
                     std::error_code(::GetLastError(), std::system_category()), std::string("PluginError: Couldn't find ") + procname);

--- a/include/Proxy/MiniWindows.h
+++ b/include/Proxy/MiniWindows.h
@@ -13,7 +13,11 @@
 #        define _ARM_
 #    endif
 
-#    define NOMINMAX
+// Do not define NOMINMAX, if it's already defined (without, the
+// #define causes issues on MingW)
+#    ifndef NOMINMAX
+#        define NOMINMAX
+#    endif
 
 // https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror
 #    include <errhandlingapi.h>


### PR DESCRIPTION
## Description

Ark can currently not be cross-compiled from Linux to Windows using MingW. There are some minor incompatibilities across the code-base and missing relevant compilation options.

This PR enables compatibility with `x86_64-w64-mingw32-c++` as the compiler,  the changes consist of some required compilation switches, and some minor code changes.

## Checklist

- [x] I have read the [Contributor guide](CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation if needed
- [x] I have added tests that prove my fix/feature is working
- [x] New and existing tests pass locally with my changes
