### PR TITLE
feat(bytecode reader): ARK-288, add line number alongside instructions in bytecode reader

### DIFF
--- a/include/Ark/Compiler/BytecodeReader.hpp
+++ b/include/Ark/Compiler/BytecodeReader.hpp
@@ -161,6 +161,15 @@ namespace Ark
         [[nodiscard]] Code code(const InstLocations& instLocations) const;
 
         /**
+         * @brief Find the location of an instruction
+         * @param inst_locations
+         * @param ip
+         * @param pp
+         * @return
+         */
+        std::optional<internal::InstLoc> findSourceLocation(const std::vector<internal::InstLoc>& inst_locations, std::size_t ip, std::size_t pp) const;
+
+        /**
          * @brief Display the bytecode opcode in a human friendly way.
          *
          * @param segment selected bytecode segment that will be displayed

--- a/include/Ark/Compiler/IntermediateRepresentation/InstLoc.hpp
+++ b/include/Ark/Compiler/IntermediateRepresentation/InstLoc.hpp
@@ -12,6 +12,8 @@ namespace Ark::internal
         uint16_t inst_pointer;
         uint16_t filename_id;
         uint32_t line;
+
+        std::strong_ordering operator<=>(const InstLoc&) const = default;
     };
 }
 

--- a/src/arkreactor/Compiler/BytecodeReader.cpp
+++ b/src/arkreactor/Compiler/BytecodeReader.cpp
@@ -271,6 +271,29 @@ namespace Ark
         return block;
     }
 
+    std::optional<InstLoc> BytecodeReader::findSourceLocation(const std::vector<InstLoc>& inst_locations, const std::size_t ip, const std::size_t pp) const
+    {
+        std::optional<InstLoc> match = std::nullopt;
+
+        for (const auto location : inst_locations)
+        {
+            if (location.page_pointer == pp && !match)
+                match = location;
+
+            // select the best match: we want to find the location that's nearest our instruction pointer,
+            // but not equal to it as the IP will always be pointing to the next instruction,
+            // not yet executed. Thus, the erroneous instruction is the previous one.
+            if (location.page_pointer == pp && match && location.inst_pointer < ip / 4)
+                match = location;
+
+            // early exit because we won't find anything better, as inst locations are ordered by ascending (pp, ip)
+            if (location.page_pointer > pp || (location.page_pointer == pp && location.inst_pointer >= ip / 4))
+                break;
+        }
+
+        return match;
+    }
+
     void BytecodeReader::display(const BytecodeSegment segment,
                                  const std::optional<uint16_t> sStart,
                                  const std::optional<uint16_t> sEnd,
@@ -638,13 +661,27 @@ namespace Ark
                         return;
                     }
 
+                    std::optional<InstLoc> previous_loc = std::nullopt;
+
                     for (std::size_t j = sStart.value_or(0), end = sEnd.value_or(page.size()); j < end; j += 4)
                     {
                         const uint8_t inst = page[j];
-                        // TEMP
                         const uint8_t padding = page[j + 1];
                         const auto arg = static_cast<uint16_t>((page[j + 2] << 8) + page[j + 3]);
 
+                        auto maybe_loc = findSourceLocation(inst_locs.locations, j, pp);
+
+                        // location
+                        // we want to print it only when it changed, either the file, the line, or both
+                        if (maybe_loc && (!previous_loc || maybe_loc != previous_loc))
+                        {
+                            if (!previous_loc || previous_loc->filename_id != maybe_loc->filename_id)
+                                fmt::println("{}", files.filenames[maybe_loc->filename_id]);
+                            fmt::print("{:>4}", maybe_loc->line + 1);
+                            previous_loc = maybe_loc;
+                        }
+                        else
+                            fmt::print("    ");
                         // instruction number
                         fmt::print(fmt::fg(fmt::color::cyan), "{:>4}", j / 4);
                         // padding inst arg arg


### PR DESCRIPTION
## Description

Now the bytecode reader output has the file and line number:

```
Code segment 0 (length: 48)
a.ark
   1   0 0b 00 00 03 PUSH_RETURN_ADDRESS
       1 3c 00 10 00 LOAD_CONST_LOAD_CONST value (String), key (String)
       2 52 00 20 3a CALL_BUILTIN dict, 2
       3 05 00 00 00 STORE a
       4 0b 00 00 0a PUSH_RETURN_ADDRESS
       5 0f 00 00 00 BUILTIN false
       6 0f 00 00 01 BUILTIN true
       7 3c 00 30 02 LOAD_CONST_LOAD_CONST 2 (Number), 1 (Number)
   2   8 3c 00 10 00 LOAD_CONST_LOAD_CONST value (String), key (String)
       9 52 00 60 3a CALL_BUILTIN dict, 6
      10 53 00 10 09 CALL_BUILTIN_WITHOUT_RETURN_ADDRESS print, 1
      11 0a 00 00 00 HALT

# for the following code
(let a (dict "key" "value"))
(let b (dict "key" "value" 1 2 true false))

(print a)
```

## Checklist

- [x] I have read the [Contributor guide](https://arkscript-lang.dev/docs/guides/contributing/)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation if needed (on https://github.com/ArkScript-lang/website, content/docs/)
- [ ] I have added tests that prove my fix/feature is working
- [x] New and existing tests pass locally with my changes
