### PR TITLE
Trying to understand why Windows CI tests are broken

### DIFF
--- a/src/arkreactor/Error/Diagnostics.cpp
+++ b/src/arkreactor/Error/Diagnostics.cpp
@@ -193,9 +193,11 @@ namespace Ark::Diagnostics
                 const std::string& filename, const internal::FileSpan& at,
                 const std::optional<CodeErrorContext>& maybe_context = std::nullopt)
     {
+        std::string uniformised_filename;
+        std::ranges::replace_copy(filename, std::back_inserter(uniformised_filename), '\\', '/');
         makeContext(
             ErrorLocation {
-                .filename = filename,
+                .filename = uniformised_filename,
                 .start = at.start,
                 .end = at.end },
             os, maybe_context, colorize);

--- a/src/arkreactor/Error/Diagnostics.cpp
+++ b/src/arkreactor/Error/Diagnostics.cpp
@@ -65,7 +65,9 @@ namespace Ark::Diagnostics
         else if (maybe_context && !ctx_same_file && !maybe_context->filename.empty())
         {
             // show the location of the parent of our error first
-            fmt::print(os, "Error originated from file {}:{}\n", maybe_context->filename, maybe_context->at.start.line + 1);
+            std::string uniformised_filename;
+            std::ranges::replace_copy(maybe_context->filename, std::back_inserter(uniformised_filename), '\\', '/');
+            fmt::print(os, "Error originated from file {}:{}\n", uniformised_filename, maybe_context->at.start.line + 1);
 
             std::optional<decltype(internal::FilePos::line)> maybe_end_line = std::nullopt;
             if (maybe_context->at.end)

--- a/tests/unittests/Main.cpp
+++ b/tests/unittests/Main.cpp
@@ -1,3 +1,6 @@
+#include "TestsHelper.hpp"
+
+
 #include <boost/ut.hpp>
 #include <fmt/format.h>
 #include <fmt/chrono.h>
@@ -17,6 +20,10 @@ int main(const int argc, char** argv)
     std::string filter = "*";
     if (argc >= 2 && std::string(argv[1]) != "update")
         filter = argv[1];
+
+    const auto path = getResourcePath("DiagnosticsSuite/runtime");
+    for (const auto& entry : std::filesystem::directory_iterator(path))
+        std::cout << "# " << entry.path().generic_string() << std::endl;
 
     bool failed = false;
     const auto start = std::chrono::high_resolution_clock::now();

--- a/tests/unittests/Main.cpp
+++ b/tests/unittests/Main.cpp
@@ -21,9 +21,14 @@ int main(const int argc, char** argv)
     if (argc >= 2 && std::string(argv[1]) != "update")
         filter = argv[1];
 
-    const auto path = getResourcePath("DiagnosticsSuite/runtime");
-    for (const auto& entry : std::filesystem::directory_iterator(path))
-        std::cout << "# " << entry.path().generic_string() << std::endl;
+    auto show = [](const std::string& res) {
+        const auto path = getResourcePath(res);
+        for (const auto& entry : std::filesystem::directory_iterator(path))
+            std::cout << "# " << entry.path().generic_string() << std::endl;
+    };
+    show("DiagnosticsSuite/compileTime");
+    show("DiagnosticsSuite/runtime");
+    show("DiagnosticsSuite/typeChecking");
 
     bool failed = false;
     const auto start = std::chrono::high_resolution_clock::now();

--- a/tests/unittests/Main.cpp
+++ b/tests/unittests/Main.cpp
@@ -7,31 +7,6 @@
 #include <string>
 #include <chrono>
 
-void tt(const std::string& folder, std::function<void(const std::string&)>&& run)
-{
-    boost::ut::test(folder) = [=] {
-        for (const std::string& name : {
-            "11111111111111111111111111111111111111111111111111111111",
-            "2222222222222222222222222222222222222222222222222222222222",
-            "2222222222222222222222222222222222222222222222222222222222",
-            "333333333333333333333333333333333333333333333333333333333333"})
-        {
-            run(name);
-        }
-    };
-}
-
-boost::ut::suite<"Main"> main_suite = [] {
-    using namespace boost::ut;
-
-    tt("main", [](const std::string& name) {
-        should("parametrized " + name) = [] {
-            expect(true);
-            expect(false);
-        };
-    });
-};
-
 int main(const int argc, char** argv)
 {
     using namespace boost;

--- a/tests/unittests/Main.cpp
+++ b/tests/unittests/Main.cpp
@@ -1,6 +1,3 @@
-#include "TestsHelper.hpp"
-
-
 #include <boost/ut.hpp>
 #include <fmt/format.h>
 #include <fmt/chrono.h>
@@ -9,6 +6,31 @@
 
 #include <string>
 #include <chrono>
+
+void tt(const std::string& folder, std::function<void(const std::string&)>&& run)
+{
+    boost::ut::test(folder) = [=] {
+        for (const std::string& name : {
+            "11111111111111111111111111111111111111111111111111111111",
+            "2222222222222222222222222222222222222222222222222222222222",
+            "2222222222222222222222222222222222222222222222222222222222",
+            "333333333333333333333333333333333333333333333333333333333333"})
+        {
+            run(name);
+        }
+    };
+}
+
+boost::ut::suite<"Main"> main_suite = [] {
+    using namespace boost::ut;
+
+    tt("main", [](const std::string& name) {
+        should("parametrized " + name) = [] {
+            expect(true);
+            expect(false);
+        };
+    });
+};
 
 int main(const int argc, char** argv)
 {
@@ -20,15 +42,6 @@ int main(const int argc, char** argv)
     std::string filter = "*";
     if (argc >= 2 && std::string(argv[1]) != "update")
         filter = argv[1];
-
-    auto show = [](const std::string& res) {
-        const auto path = getResourcePath(res);
-        for (const auto& entry : std::filesystem::directory_iterator(path))
-            std::cout << "# " << entry.path().generic_string() << std::endl;
-    };
-    show("DiagnosticsSuite/compileTime");
-    show("DiagnosticsSuite/runtime");
-    show("DiagnosticsSuite/typeChecking");
 
     bool failed = false;
     const auto start = std::chrono::high_resolution_clock::now();

--- a/tests/unittests/Suites/CompilerSuite.cpp
+++ b/tests/unittests/Suites/CompilerSuite.cpp
@@ -81,7 +81,7 @@ ut::suite<"Compiler"> compiler_suite = [] {
 
         iterTestFiles(
             "CompilerSuite/ir",
-            [](TestData&& data) {
+            [](const TestData& data) {
                 Ark::Welder welder(0, { lib_path }, features);
 
                 should("compile without error ir/" + data.stem) = [&] {
@@ -103,7 +103,7 @@ ut::suite<"Compiler"> compiler_suite = [] {
 
         iterTestFiles(
             "CompilerSuite/optimized_ir",
-            [](TestData&& data) {
+            [](const TestData& data) {
                 Ark::Welder welder(0, { lib_path }, features);
 
                 should("compile without error optimized_ir/" + data.stem) = [&] {

--- a/tests/unittests/Suites/DiagnosticsSuite.cpp
+++ b/tests/unittests/Suites/DiagnosticsSuite.cpp
@@ -14,7 +14,7 @@ ut::suite<"Diagnostics"> diagnostics_suite = [] {
 
     iterTestFiles(
         "DiagnosticsSuite/compileTime",
-        [](TestData&& data) {
+        [](const TestData& data) {
             Ark::State state({ lib_path });
 
             should("generate an error message at compile time for compileTime/" + data.stem) = [&] {
@@ -36,7 +36,7 @@ ut::suite<"Diagnostics"> diagnostics_suite = [] {
 
     iterTestFiles(
         "DiagnosticsSuite/runtime",
-        [](TestData&& data) {
+        [](const TestData& data) {
             Ark::State state({ lib_path });
 
             should("compile without error runtime/" + data.stem) = [&] {
@@ -62,7 +62,7 @@ ut::suite<"Diagnostics"> diagnostics_suite = [] {
 
     iterTestFiles(
         "DiagnosticsSuite/typeChecking",
-        [](TestData&& data) {
+        [](const TestData& data) {
             Ark::State state({ lib_path });
 
             should("compile without error typeChecking/" + data.stem) = [&] {

--- a/tests/unittests/Suites/FormatterSuite.cpp
+++ b/tests/unittests/Suites/FormatterSuite.cpp
@@ -11,7 +11,7 @@ ut::suite<"Formatter"> formatter_suite = [] {
 
     iterTestFiles(
         "FormatterSuite",
-        [](TestData&& data) {
+        [](const TestData& data) {
             std::string formatted_code;
 
             should("output a correctly formatted code for " + data.stem) = [&] {

--- a/tests/unittests/Suites/OptimizerSuite.cpp
+++ b/tests/unittests/Suites/OptimizerSuite.cpp
@@ -13,7 +13,7 @@ ut::suite<"Optimizer"> optimizer_suite = [] {
     "[generate optimized ast]"_test = [] {
         iterTestFiles(
             "OptimizerSuite",
-            [](TestData&& data) {
+            [](const TestData& data) {
                 JsonCompiler compiler(false, { lib_path }, Ark::FeatureASTOptimizer);
 
                 std::string json;

--- a/tests/unittests/Suites/ParserSuite.cpp
+++ b/tests/unittests/Suites/ParserSuite.cpp
@@ -46,7 +46,7 @@ ut::suite<"Parser"> parser_suite = [] {
     "[successful parsing]"_test = [] {
         iterTestFiles(
             "ParserSuite/success",
-            [](TestData&& data) {
+            [](const TestData& data) {
                 Ark::internal::Parser parser(/* debug= */ 0);
 
                 should("parse " + data.stem) = [&] {
@@ -68,7 +68,7 @@ ut::suite<"Parser"> parser_suite = [] {
     "[error reporting]"_test = [] {
         iterTestFiles(
             "ParserSuite/failure",
-            [](TestData&& data) {
+            [](const TestData& data) {
                 try
                 {
                     Ark::internal::Parser parser(/* debug= */ 0);

--- a/tests/unittests/Suites/RosettaSuite.cpp
+++ b/tests/unittests/Suites/RosettaSuite.cpp
@@ -13,7 +13,7 @@ ut::suite<"Rosetta"> rosetta_suite = [] {
     "[run arkscript rosetta code solutions]"_test = [] {
         iterTestFiles(
             "RosettaSuite",
-            [](TestData&& data) {
+            [](const TestData&data) {
                 Ark::State state({ lib_path });
 
                 should("compile " + data.stem) = [&] {

--- a/tests/unittests/Suites/TypeCheckerSuite.cpp
+++ b/tests/unittests/Suites/TypeCheckerSuite.cpp
@@ -177,7 +177,7 @@ ut::suite<"TypeChecker"> type_checker_suite = [] {
 
     iterTestFiles(
         "TypeCheckerSuite",
-        [&](TestData&& data) {
+        [&](const TestData& data) {
             std::vector<Input> inputs;
             std::vector<Ark::types::Contract> contracts;
 
@@ -185,7 +185,7 @@ ut::suite<"TypeChecker"> type_checker_suite = [] {
             {
                 iterTestFiles(
                     data.path,
-                    [&inputs](TestData&& inner) {
+                    [&inputs](const TestData& inner) {
                         const Input input = parse_input(inner.path);
                         expect(fatal(input.initialized)) << "invalid test input: " << inner.stem;
                         inputs.push_back(input);

--- a/tests/unittests/Suites/ValidAstSuite.cpp
+++ b/tests/unittests/Suites/ValidAstSuite.cpp
@@ -13,7 +13,7 @@ ut::suite<"AST"> ast_suite = [] {
     "[generate valid ast]"_test = [] {
         iterTestFiles(
             "ASTSuite",
-            [](TestData&& data) {
+            [](const TestData& data) {
                 JsonCompiler compiler(false, { lib_path });
 
                 std::string json;

--- a/tests/unittests/TestsHelper.cpp
+++ b/tests/unittests/TestsHelper.cpp
@@ -28,7 +28,7 @@ void updateExpectedFile(const TestData& data, const std::string& actual)
     }
 }
 
-void iterTestFiles(const std::string& folder, std::function<void(TestData&&)>&& test, IterTestFilesParam&& params)
+void iterTestFiles(const std::string& folder, std::function<void(const TestData&)>&& test, IterTestFilesParam&& params)
 {
     boost::ut::test(folder) = [&] {
         const auto path = params.folder_is_resource ? getResourcePath(folder) : folder;
@@ -58,8 +58,8 @@ void iterTestFiles(const std::string& folder, std::function<void(TestData&&)>&& 
                 .is_folder = is_directory(entry.path())
             };
 
-            std::cout << "test on '" << entry.path().generic_string() << std::endl;
-            test(std::move(data));
+            std::cout << "test on '" << entry.path().generic_string() << "'" << std::endl;
+            test(data);
         }
     };
 }

--- a/tests/unittests/TestsHelper.cpp
+++ b/tests/unittests/TestsHelper.cpp
@@ -58,7 +58,6 @@ void iterTestFiles(const std::string& folder, std::function<void(const TestData&
                 .is_folder = is_directory(entry.path())
             };
 
-            std::cout << "test on '" << entry.path().generic_string() << "'" << std::endl;
             test(data);
         }
     };

--- a/tests/unittests/TestsHelper.cpp
+++ b/tests/unittests/TestsHelper.cpp
@@ -58,6 +58,7 @@ void iterTestFiles(const std::string& folder, std::function<void(TestData&&)>&& 
                 .is_folder = is_directory(entry.path())
             };
 
+            std::cout << "test on '" << entry.path().generic_string() << std::endl;
             test(std::move(data));
         }
     };

--- a/tests/unittests/TestsHelper.cpp
+++ b/tests/unittests/TestsHelper.cpp
@@ -75,6 +75,7 @@ std::string sanitizeCodeError(const Ark::CodeError& e)
 
     std::string diag = stream.str();
     diag.erase(std::ranges::remove(diag, '\r').begin(), diag.end());
+
     while (diag.find(ARK_TESTS_ROOT) != std::string::npos)
         diag.erase(diag.find(ARK_TESTS_ROOT), std::size(ARK_TESTS_ROOT) - 1);
 

--- a/tests/unittests/TestsHelper.hpp
+++ b/tests/unittests/TestsHelper.hpp
@@ -52,7 +52,7 @@ void updateExpectedFile(const TestData& data, const std::string& actual);
  * @param test test function, taking a TestData&& with the paths of the input and its expected result
  * @param params optionally specify the expected extension. Defaults to "expected"
  */
-void iterTestFiles(const std::string& folder, std::function<void(TestData&&)>&& test, IterTestFilesParam&& params = {});
+void iterTestFiles(const std::string& folder, std::function<void(const TestData&)>&& test, IterTestFilesParam&& params = {});
 
 /**
  * @brief Given an input folder, returns the resource path relatives to the project root


### PR DESCRIPTION
`fix: use const string instead of constexpr string, otherwise compiler` works when retrying the CI on dev, but not in this PR