### PR TITLE
fix(formatter): don't forget to add the indentation when a condition is on a newline

### DIFF
--- a/src/arkscript/Formatter.cpp
+++ b/src/arkscript/Formatter.cpp
@@ -359,7 +359,7 @@ std::string Formatter::formatCondition(const Node& node, const std::size_t inden
     const Node then_node = node.constList()[2];
 
     bool cond_on_newline = false;
-    std::string formatted_cond = format(cond_node, indent + 1, false);
+    const std::string formatted_cond = format(cond_node, indent + 1, false);
     if (formatted_cond.find('\n') != std::string::npos)
         cond_on_newline = true;
 
@@ -367,7 +367,7 @@ std::string Formatter::formatCondition(const Node& node, const std::size_t inden
         "({}if{}{}",
         is_macro ? "$" : "",
         cond_on_newline ? "\n" : " ",
-        formatted_cond);
+        cond_on_newline ? format(cond_node, indent + 1, true) : formatted_cond);
 
     const bool split_then_newline = shouldSplitOnNewline(then_node) || isBeginBlock(then_node);
 

--- a/tests/unittests/resources/FormatterSuite/codeSamples/permutations.ark
+++ b/tests/unittests/resources/FormatterSuite/codeSamples/permutations.ark
@@ -1,0 +1,26 @@
+(let permutations (fun ((ref _L) _r _f) {
+  (let _len (len _L))
+  (if (and (<= _r _len) (> _r 0))
+    {
+      (mut _indices (iota 0 _r))
+      (if (!= stopIteration (_f (select _L _indices)))
+        {
+          (mut _continue true)
+          (let _reversed_indices (reverse _indices))
+          (while _continue {
+            (mut _i nil)
+            (if
+              (forEach
+                _reversed_indices
+                (fun (_val) {
+                  (set _i _val)
+                  (if (!= (@ _indices _i) (+ _i _len (* -1 _r))) stopIteration) }))
+              {
+                (@= _indices _i (+ 1 (@ _indices _i)))
+                (mut _j (+ 1 _i))
+                (while (< _j _r) {
+                  (@= _indices _j (+ 1 (@ _indices (- _j 1))))
+                  (set _j (+ 1 _j)) })
+                (if (= stopIteration (_f (select _L _indices)))
+                  (set _continue false)) }
+              (set _continue false)) }) }) }) }))

--- a/tests/unittests/resources/FormatterSuite/codeSamples/permutations.expected
+++ b/tests/unittests/resources/FormatterSuite/codeSamples/permutations.expected
@@ -1,0 +1,26 @@
+(let permutations (fun ((ref _L) _r _f) {
+  (let _len (len _L))
+  (if (and (<= _r _len) (> _r 0))
+    {
+      (mut _indices (iota 0 _r))
+      (if (!= stopIteration (_f (select _L _indices)))
+        {
+          (mut _continue true)
+          (let _reversed_indices (reverse _indices))
+          (while _continue {
+            (mut _i nil)
+            (if
+              (forEach
+                _reversed_indices
+                (fun (_val) {
+                  (set _i _val)
+                  (if (!= (@ _indices _i) (+ _i _len (* -1 _r))) stopIteration) }))
+              {
+                (@= _indices _i (+ 1 (@ _indices _i)))
+                (mut _j (+ 1 _i))
+                (while (< _j _r) {
+                  (@= _indices _j (+ 1 (@ _indices (- _j 1))))
+                  (set _j (+ 1 _j)) })
+                (if (= stopIteration (_f (select _L _indices)))
+                  (set _continue false)) }
+              (set _continue false)) }) }) }) }))

--- a/tools/ark_format
+++ b/tools/ark_format
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+for f in *.ark; do
+  arkscript -f "$f"
+  if [[ $? == 1 ]]; then
+    echo "Formatted $f"
+  fi
+done
+
+echo "All files in $(pwd) are correctly formatted!"


### PR DESCRIPTION
## Description

When a condition is on a newline, and the indentation level is more than 0, conditions were put at column 0, which is an error:

```diff
 (let permutations (fun ((ref _L) _r _f) {
   (let _len (len _L))
   (if (and (<= _r _len) (> _r 0))
     {
       (mut _indices (iota 0 _r))
       (if (!= stopIteration (_f (select _L _indices)))
         {
           (mut _continue true)
           (let _reversed_indices (reverse _indices))
           (while _continue {
             (mut _i nil)
             (if
-              (forEach
+(forEach
                 _reversed_indices
                 (fun (_val) {
                   (set _i _val)
                   (if (!= (@ _indices _i) (+ _i _len (* -1 _r))) stopIteration) }))
               {
                 (@= _indices _i (+ 1 (@ _indices _i)))
                 (mut _j (+ 1 _i))
                 (while (< _j _r) {
                   (@= _indices _j (+ 1 (@ _indices (- _j 1))))
                   (set _j (+ 1 _j)) })
                 (if (= stopIteration (_f (select _L _indices)))
                   (set _continue false)) }
               (set _continue false)) }) }) }) }))

```

## Checklist

- [x] I have read the [Contributor guide](https://arkscript-lang.dev/docs/guides/contributing/)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation if needed (on https://github.com/ArkScript-lang/website, content/docs/)
- [x] I have added tests that prove my fix/feature is working
- [x] New and existing tests pass locally with my changes
