### PR TITLE
feat(diagnostics): ARK-321, allow generating diagnostics from string instead of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Huge thanks to those people for their donations to support the project:
 
 ## Credits
 
-This project was inspired by [game programing patterns](http://gameprogrammingpatterns.com/bytecode.html) and [ofan lisp.cpp](https://gist.github.com/ofan/721464)
+This project was inspired by [game programing patterns](http://gameprogrammingpatterns.com/bytecode.html) and [anthay/Lisp90](https://github.com/anthay/Lisp90)
 
 ## Copyright and Licence information
 

--- a/include/Ark/Error/Diagnostics.hpp
+++ b/include/Ark/Error/Diagnostics.hpp
@@ -26,6 +26,7 @@ namespace Ark::Diagnostics
         std::string filename;  ///< Complete path to the file where the error is
         internal::FilePos start;
         std::optional<internal::FilePos> end;
+        std::optional<std::string> maybe_content;
 
         [[nodiscard]] bool wholeLineIsError() const
         {
@@ -62,6 +63,8 @@ namespace Ark::Diagnostics
      * @return std::string
      */
     std::string makeContextWithNode(const std::string& message, const internal::Node& node);
+
+    ARK_API void generateWithCode(const CodeError& e, const std::string& code, std::ostream& os = std::cout, bool colorize = true);
 
     /**
      * @brief Generate a diagnostic from an error and print it to the standard output

--- a/include/Ark/Error/PrettyPrinting.hpp
+++ b/include/Ark/Error/PrettyPrinting.hpp
@@ -68,8 +68,9 @@ namespace Ark::Diagnostics
          * @param target_line line of the error (0-indexed)
          * @param end_target_line optional end line for the error (0-indexed)
          * @param colorize if we should colorize the output or not
+         * @param maybe_content optional file content, if it was originally a string (via State.doString)
          */
-        Printer(const std::string& filename, std::size_t target_line, std::optional<std::size_t> end_target_line, bool colorize);
+        Printer(const std::string& filename, std::size_t target_line, std::optional<std::size_t> end_target_line, bool colorize, const std::optional<std::string>& maybe_content = std::nullopt);
 
         /**
          * @brief Slice the source code to get code between two cursors

--- a/include/Ark/VM/VM.hpp
+++ b/include/Ark/VM/VM.hpp
@@ -167,7 +167,7 @@ namespace Ark
          */
         [[noreturn]] static void throwVMError(internal::ErrorKind kind, const std::string& message);
 
-        inline const bytecode_t& bytecode() const
+        [[nodiscard]] inline const bytecode_t& bytecode() const
         {
             return m_state.m_bytecode;
         }

--- a/src/arkreactor/Compiler/Welder.cpp
+++ b/src/arkreactor/Compiler/Welder.cpp
@@ -204,7 +204,10 @@ namespace Ark
             if ((m_features & FeatureTestFailOnException) > 0)
                 throw;
 
-            Diagnostics::generate(e);
+            if (filename != ARK_NO_NAME_FILE)
+                Diagnostics::generate(e);
+            else
+                Diagnostics::generateWithCode(e, code);
             return false;
         }
     }

--- a/src/arkreactor/Error/Diagnostics.cpp
+++ b/src/arkreactor/Error/Diagnostics.cpp
@@ -50,7 +50,7 @@ namespace Ark::Diagnostics
     {
         assert(!(maybe_context && loc.wholeLineIsError()) && "Can not create error context when a context is given AND the whole line has to be underlined");
 
-        Printer source_printer(loc.filename, loc.start.line, loc.maybeEndLine(), colorize);
+        Printer source_printer(loc.filename, loc.start.line, loc.maybeEndLine(), colorize, loc.maybe_content);
         if (!source_printer.hasContent())
         {
             showFileLocation(os, loc);
@@ -193,7 +193,8 @@ namespace Ark::Diagnostics
 
     void helper(std::ostream& os, const std::string& message, const bool colorize,
                 const std::string& filename, const internal::FileSpan& at,
-                const std::optional<CodeErrorContext>& maybe_context = std::nullopt)
+                const std::optional<CodeErrorContext>& maybe_context = std::nullopt,
+                const std::optional<std::string>& maybe_file_content = std::nullopt)
     {
         std::string uniformised_filename;
         std::ranges::replace_copy(filename, std::back_inserter(uniformised_filename), '\\', '/');
@@ -201,7 +202,8 @@ namespace Ark::Diagnostics
             ErrorLocation {
                 .filename = uniformised_filename,
                 .start = at.start,
-                .end = at.end },
+                .end = at.end,
+                .maybe_content = maybe_file_content },
             os, maybe_context, colorize);
 
         for (const auto& text : Utils::splitString(message, '\n'))
@@ -220,6 +222,23 @@ namespace Ark::Diagnostics
             node.position());
 
         return ss.str();
+    }
+
+    void generateWithCode(const CodeError& e, const std::string& code, std::ostream& os, bool colorize)
+    {
+#ifdef ARK_BUILD_EXE
+        if (const char* nocolor = std::getenv("NOCOLOR"); nocolor != nullptr)
+            colorize = false;
+#endif
+
+        helper(
+            os,
+            e.what(),
+            colorize,
+            e.context.filename,
+            e.context.at,
+            e.additional_context,
+            code);
     }
 
     void generate(const CodeError& e, std::ostream& os, bool colorize)

--- a/src/arkreactor/Error/PrettyPrinting.cpp
+++ b/src/arkreactor/Error/PrettyPrinting.cpp
@@ -77,10 +77,11 @@ namespace Ark::Diagnostics
 
     Printer::Printer(
         const std::string& filename, const std::size_t target_line,
-        const std::optional<std::size_t> end_target_line, const bool colorize) :
+        const std::optional<std::size_t> end_target_line, const bool colorize,
+        const std::optional<std::string>& maybe_content) :
         m_should_colorize(colorize)
     {
-        const std::string code = filename == ARK_NO_NAME_FILE ? "" : Utils::readFile(filename);
+        const std::string code = filename == ARK_NO_NAME_FILE ? maybe_content.value_or("") : Utils::readFile(filename);
         m_source = Utils::splitString(code, '\n');
 
         m_window = Window(target_line, end_target_line.value_or(target_line), m_source.size());

--- a/src/arkreactor/VM/Debugger.cpp
+++ b/src/arkreactor/VM/Debugger.cpp
@@ -133,7 +133,8 @@ namespace Ark::internal
                     Diagnostics::ErrorLocation {
                         .filename = filename,
                         .start = FilePos { .line = maybe_source_loc->line, .column = 0 },
-                        .end = std::nullopt },
+                        .end = std::nullopt,
+                        .maybe_content = std::nullopt },
                     m_os,
                     /* maybe_context= */ std::nullopt,
                     /* colorize= */ m_colorize);

--- a/src/arkreactor/VM/VM.cpp
+++ b/src/arkreactor/VM/VM.cpp
@@ -2366,7 +2366,8 @@ namespace Ark
                     Diagnostics::ErrorLocation {
                         .filename = filename,
                         .start = FilePos { .line = maybe_location->line, .column = 0 },
-                        .end = std::nullopt },
+                        .end = std::nullopt,
+                        .maybe_content = std::nullopt },
                     os,
                     /* maybe_context= */ std::nullopt,
                     /* colorize= */ colorize);

--- a/tests/unittests/Suites/EmbeddingSuite.cpp
+++ b/tests/unittests/Suites/EmbeddingSuite.cpp
@@ -4,11 +4,13 @@
 #include <Ark/Utils/Literals.hpp>
 #include <Ark/Utils/Utils.hpp>
 #include <vector>
+#include <TestsHelper.hpp>
 #include <iostream>
 
 using namespace boost;
 using namespace Ark::literals;
 
+// cppcheck-suppress [constParameterCallback, constParameterReference]
 Ark::Value my_function(std::vector<Ark::Value>& args, Ark::VM* vm [[maybe_unused]])
 {
     // checking argument number
@@ -187,6 +189,7 @@ ut::suite<"Embedding"> embedding_suite = [] {
         Ark::State state;
 
         int capture = 42;
+        // cppcheck-suppress constParameterReference
         state.loadFunction("my_function", [=](std::vector<Ark::Value>& args, [[maybe_unused]] Ark::VM* /*vm*/) {
             int solution = 0;
             for (const Ark::Value& value : args)
@@ -215,7 +218,8 @@ ut::suite<"Embedding"> embedding_suite = [] {
     "[load cpp function with captured reference]"_test = [] {
         Ark::State state;
 
-        std::string name = "";
+        std::string name;
+        // cppcheck-suppress constParameterReference
         state.loadFunction("my_function", [&name](std::vector<Ark::Value>& args, [[maybe_unused]] Ark::VM* /*vm*/) {
             for (const Ark::Value& value : args)
             {
@@ -243,6 +247,7 @@ ut::suite<"Embedding"> embedding_suite = [] {
     "[load cpp function and call it from arkscript]"_test = [] {
         Ark::State state;
         state.loadFunction("my_function", my_function);
+        // cppcheck-suppress constParameterReference
         state.loadFunction("foo", [](std::vector<Ark::Value>& args, Ark::VM* /*vm*/) {
             return Ark::Value(static_cast<int>(args.size()));
         });
@@ -305,6 +310,33 @@ ut::suite<"Embedding"> embedding_suite = [] {
         };
     };
 
+    "[fail to compile embedded code]"_test = [] {
+        constexpr uint16_t features = Ark::DefaultFeatures | Ark::FeatureTestFailOnException;
+        Ark::State state({ ARK_TESTS_ROOT "lib" });
+        const std::string code = "(import std.Sys) (let foo sys:args) (let b bar)";
+        const std::string expected = R"(    1 | (import std.Sys) (let foo sys:args) (let b bar)
+      |                                            ^~~
+        Unbound variable error "bar" (variable is used but not defined))";
+
+        should("compile the string with an error") = [&] {
+            try
+            {
+                const bool ok = mut(state).doString(code, features);
+                expect(!ok) << fatal;  // we shouldn't be here, the compilation has to fail
+            }
+            catch (const Ark::CodeError& e)
+            {
+                std::stringstream stream;
+                Ark::Diagnostics::generateWithCode(e, code, stream, /* colorize= */ false);
+                std::string diag = stream.str();
+                diag.erase(std::ranges::remove(diag, '\r').begin(), diag.end());
+                Ark::Utils::rtrim(diag);
+
+                expectOrDiff(expected, diag);
+            }
+        };
+    };
+
     "[retrieve sys:args in embedded code]"_test = [] {
         Ark::State state({ ARK_TESTS_ROOT "lib" });
 
@@ -313,10 +345,8 @@ ut::suite<"Embedding"> embedding_suite = [] {
         };
 
         Ark::VM vm(state);
-        double timestamp = 0.0;
         should("return exit code 0") = [&] {
             expect(mut(vm).run() == 0_i);
-            timestamp = vm["t"].number();
         };
 
         should("have symbol foo registered") = [&] {
@@ -335,10 +365,8 @@ ut::suite<"Embedding"> embedding_suite = [] {
         };
 
         Ark::VM vm(state);
-        double timestamp = 0.0;
         should("return exit code 0") = [&] {
             expect(mut(vm).run() == 0_i);
-            timestamp = vm["t"].number();
         };
 
         should("have symbol foo registered") = [&] {
@@ -353,6 +381,7 @@ ut::suite<"Embedding"> embedding_suite = [] {
 
     "[load usertype and cpp lambdas and call them from arkscript]"_test = [] {
         Ark::State state;
+        // cppcheck-suppress constParameterReference
         state.loadFunction("getBreakfast", [](std::vector<Ark::Value>& n [[maybe_unused]], Ark::VM* vm [[maybe_unused]]) -> Ark::Value {
             // we need to send the address of the object, which will be cast
             // to void* internally
@@ -366,7 +395,7 @@ ut::suite<"Embedding"> embedding_suite = [] {
         state.loadFunction("useBreakfast", [](std::vector<Ark::Value>& n, Ark::VM* vm [[maybe_unused]]) -> Ark::Value {
             if (n[0].valueType() == Ark::ValueType::User && n[0].usertype().is<Breakfast>())
             {
-                auto& bf = n[0].usertypeRef().as<Breakfast>();
+                const auto& bf = n[0].usertypeRef().as<Breakfast>();
                 if (bf == Breakfast::Pizza)
                     return Ark::Value(1);
                 return Ark::Value(2);


### PR DESCRIPTION
## Description

Generating compile-time errors from `State.doString` is now a thing for a better debugging experience when embedding ArkScript.

## Checklist

- [x] I have read the [Contributor guide](https://arkscript-lang.dev/docs/guides/contributing/)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation if needed (on https://github.com/ArkScript-lang/website, content/docs/)
- [x] I have added tests that prove my fix/feature is working
- [x] New and existing tests pass locally with my changes
