### PR TITLE
chore(ci): update clang format version used in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run clang-format style check for C/C++/Protobuf programs.
         uses: jidicula/clang-format-action@6cd220de46c89139a0365edae93eee8eb30ca8fe  # v4.16.0
         with:
-          clang-format-version: '13'
+          clang-format-version: '19'
           check-path: ${{ matrix.path }}
           fallback-style: 'Mozilla' # optional
 

--- a/src/arkreactor/Compiler/Welder.cpp
+++ b/src/arkreactor/Compiler/Welder.cpp
@@ -28,7 +28,7 @@ namespace Ark
         m_lowerer(debug),
         m_ir_optimizer(debug),
         m_ir_compiler(debug)
-    { }
+    {}
 
     void Welder::registerSymbol(const std::string& name)
     {


### PR DESCRIPTION
## Description

Use a more recent version of clang format in the CI.

## Checklist

- [ ] I have read the [Contributor guide](https://arkscript-lang.dev/docs/guides/contributing/)
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation if needed (on https://github.com/ArkScript-lang/website, content/docs/)
- [ ] I have added tests that prove my fix/feature is working
- [ ] New and existing tests pass locally with my changes
