### PR TITLE
feat(vm): use a bitwise op instead of modulo in the VM when checking …

### DIFF
--- a/src/arkreactor/VM/VM.cpp
+++ b/src/arkreactor/VM/VM.cpp
@@ -470,7 +470,7 @@ namespace Ark
         arg = static_cast<uint16_t>((m_state.inst(context.pp, context.ip + 2) << 8) +                     \
                                     m_state.inst(context.pp, context.ip + 3));                            \
         context.ip += 4;                                                                                  \
-        context.inst_exec_counter = (context.inst_exec_counter + 1) % VMOverflowBufferSize;               \
+        context.inst_exec_counter = (context.inst_exec_counter + 1) & VMOverflowBufferSize;               \
         if constexpr (WithDebugger)                                                                       \
         {                                                                                                 \
             if (!m_debugger) initDebugger(context);                                                       \


### PR DESCRIPTION
…for stack overflows
## Description

Modulo are slower than bitwise operation, lets test that assumption.

## Checklist

- [ ] I have read the [Contributor guide](https://arkscript-lang.dev/docs/guides/contributing/)
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation if needed (on https://github.com/ArkScript-lang/website, content/docs/)
- [ ] I have added tests that prove my fix/feature is working
- [ ] New and existing tests pass locally with my changes
- [ ] I confirm that I am the author of this code and release it to the ArkScript project under the MPL-2.0 license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").
