### PR TITLE
fix(compiler): ensure there is a variable to mark as unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [4.5.2] - 2026-05-06
+### Changed
+- fix compiler segfault when there is no variable to mark as unreachable
+
 ## [4.5.1] - 2026-05-05
 ### Added
 - special error message when trying to use a hidden symbol due to importing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(ark CXX)
 # ArkScript version (have to manually update it)
 set(ARK_VERSION_MAJOR 4)
 set(ARK_VERSION_MINOR 5)
-set(ARK_VERSION_PATCH 1)
+set(ARK_VERSION_PATCH 2)
 set(ARK_VERSION_PRERELEASE 0)
 
 # determine whether this is a standalone project or included by other projects

--- a/include/Ark/Utils/Platform.hpp
+++ b/include/Ark/Utils/Platform.hpp
@@ -17,10 +17,12 @@
 #    define ARK_OS_LINUX
 #endif
 
-#if defined(__GNUC__) || defined(__clang__)
-#    define ARK_ALWAYS_INLINE __attribute__((always_inline))
-#elif defined(_MSC_VER) && !defined(__clang__)
-#    define ARK_ALWAYS_INLINE __forceinline
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#    if defined(__GNUC__) || defined(__clang__)
+#        define ARK_ALWAYS_INLINE __attribute__((always_inline))
+#    elif defined(_MSC_VER) && !defined(__clang__)
+#        define ARK_ALWAYS_INLINE __forceinline
+#    endif
 #else
 #    define ARK_ALWAYS_INLINE
 #endif

--- a/src/arkreactor/Compiler/Lowerer/LocalsLocator.cpp
+++ b/src/arkreactor/Compiler/Lowerer/LocalsLocator.cpp
@@ -76,6 +76,7 @@ namespace Ark::internal
 
     void LocalsLocator::markLastLocalAsUnreachable()
     {
-        m_scopes.back().data.back().unreachable = true;
+        if (!m_scopes.back().data.empty())
+            m_scopes.back().data.back().unreachable = true;
     }
 }

--- a/tests/unittests/resources/LangSuite/weird-tests.ark
+++ b/tests/unittests/resources/LangSuite/weird-tests.ark
@@ -110,4 +110,12 @@
       (test:eq res 5) }))
 
     (var_after_cond false)
-    (var_after_cond true) }) })
+    (var_after_cond true) })
+
+  (test:case "no segfault when marking variables as unreachable in the compiler" {
+    (mut n 1)
+    (while (< n 10) {
+      (if (> n 1)
+        ((let F (fun (m) (if m m 1))) n))
+      (set n (+ n 1)) })
+    (test:eq n 10) }) })


### PR DESCRIPTION
## Description

Forgot to add bound checking, so sometimes the compiler segfaulted.

## Checklist

- [x] I have read the [Contributor guide](https://arkscript-lang.dev/docs/guides/contributing/)
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation if needed (on https://github.com/ArkScript-lang/website, content/docs/)
- [x] I have added tests that prove my fix/feature is working
- [x] New and existing tests pass locally with my changes
- [x] I confirm that I am the author of this code and release it to the ArkScript project under the MPL-2.0 license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").
