### PR TITLE
fix: added un-included cstdint header in VM/Value/Closure.hpp

### DIFF
--- a/include/Ark/VM/Value/Closure.hpp
+++ b/include/Ark/VM/Value/Closure.hpp
@@ -13,6 +13,7 @@
 
 #include <memory>
 #include <string>
+#include <cstdint>
 
 #include <Ark/Utils/Platform.hpp>
 


### PR DESCRIPTION
## Description

So while building ark, i ran into this issue: 
```bash
[ 82%] Building CXX object CMakeFiles/ArkReactor.dir/src/arkreactor/VM/Value/Dict.cpp.o
[ 84%] Building CXX object CMakeFiles/ArkReactor.dir/src/arkreactor/VM/Value/Future.cpp.o
In file included from /home/curl0z/dev/git/my-ark/src/arkreactor/VM/Value/Closure.cpp:1:
/home/curl0z/dev/git/my-ark/include/Ark/VM/Value/Closure.hpp:26:24: error: ‘uint16_t’ does not name a type
   26 |     using PageAddr_t = uint16_t;
      |                        ^~~~~~~~
/home/curl0z/dev/git/my-ark/include/Ark/VM/Value/Closure.hpp:18:1: note: ‘uint16_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   17 | #include <Ark/Utils/Platform.hpp>
  +++ |+#include <cstdint>
   18 |
/home/curl0z/dev/git/my-ark/include/Ark/VM/Value/Closure.hpp:43:44: error: ‘PageAddr_t’ has not been declared; did you mean ‘daddr_t’?
   43 |         Closure(const ClosureScope& scope, PageAddr_t pa) noexcept;
      |                                            ^~~~~~~~~~
      |                                            daddr_t

rest were same trailing issue
```

Fix was well very simple, just added the header in blamed file.
Closes #701

## Checklist

- [ ] I have read the [Contributor guide](https://arkscript-lang.dev/docs/guides/contributing/)
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation if needed (on https://github.com/ArkScript-lang/website, content/docs/)
- [ ] I have added tests that prove my fix/feature is working
- [ ] New and existing tests pass locally with my changes
- [ ] I confirm that I am the author of this code and release it to the ArkScript project under the MPL-2.0 license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").
