### PR TITLE
fix(ci): use a dedicated workflow to write comments on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ on:
   pull_request:
 
 permissions:
-  pull-requests: write  # Required for commenting on pull requests
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -272,71 +272,6 @@ jobs:
             exit 1
           fi
 
-  check-super-insts-usage:
-    runs-on: ubuntu-24.04
-    name: Check Super Instructions usage
-    needs: [ check ]
-
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          submodules: recursive
-
-      - name: Setup compilers, dependencies, project and build
-        uses: ./.github/workflows/setup-compilers
-        with:
-          os_name: ubuntu-24.04
-          compiler: clang
-          compiler_version: 16
-          sanitizers: "On"
-          with_deps: false
-
-      - uses: actions/setup-python@v6
-        if: ${{ ! startsWith(matrix.config.name, 'Windows') }}
-        with:
-          python-version: '3.13'
-
-      - run: |
-          echo "SUPER_INSTS_REPORT<<EOF" >> $GITHUB_ENV
-          python3 tools/ark_frequent_instructions.py super_insts_usage >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-
-      - uses: 8BitJonny/gh-get-current-pr@4.0.0
-        id: PR
-        with:
-          sha: ${{ github.event.pull_request.head.sha }}
-          # Only return if PR is still open
-          filterOutClosed: true
-
-      - run: |
-          echo "PR found: ${prFound}"
-          echo "PR ${prNumber:-ERROR} ${prTitle:-NOTITLE}"
-        env:
-          # Direct access to common PR properties
-          prNumber: ${{ steps.PR.outputs.number }}
-          prTitle: ${{ steps.PR.outputs.pr_title }}
-          prFound: ${{ steps.PR.outputs.pr_found }}
-
-      - name: Find Comment
-        uses: peter-evans/find-comment@v4
-        if: steps.PR.outputs.pr_found == 'true'
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: Super Instructions report
-
-      - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v5.0.0
-        if: steps.PR.outputs.pr_found == 'true'
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            ## Super Instructions report
-            ${{ env.SUPER_INSTS_REPORT }}
-          edit-mode: replace
-
   build:
     runs-on: ${{ matrix.config.os }}
     name: ${{ matrix.config.name }}
@@ -584,15 +519,6 @@ jobs:
           # Only return if PR is still open
           filterOutClosed: true
 
-      - run: |
-          echo "PR found: ${prFound}"
-          echo "PR ${prNumber:-ERROR} ${prTitle:-NOTITLE}"
-        env:
-          # Direct access to common PR properties
-          prNumber: ${{ steps.PR.outputs.number }}
-          prTitle: ${{ steps.PR.outputs.pr_title }}
-          prFound: ${{ steps.PR.outputs.pr_found }}
-
       - name: Summarize for PR
         id: summary
         if: steps.PR.outputs.pr_found == 'true'
@@ -610,25 +536,21 @@ jobs:
           afl-whatsup -s -d output
           afl-showmap -C -i output -o /dev/null -- ./${BUILD_FOLDER}/arkscript -L ./lib @@
 
-      - name: Find Comment
-        uses: peter-evans/find-comment@v4
+      - name: Save PR identifiers
         if: steps.PR.outputs.pr_found == 'true'
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: Fuzzing report
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+          echo "Fuzzing report" > ./pr/slug
 
-      - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v5.0.0
+          echo "## Fuzzing report" > ./pr/comment
+          echo "${{ env.FUZZ_SUMMARY }}" >> ./pr/comment
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: steps.PR.outputs.pr_found == 'true'
         with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            ## Fuzzing report
-            ${{ env.FUZZ_SUMMARY }}
-          edit-mode: replace
+          name: pr
+          path: pr/
 
       - name: Sort files for upload
         continue-on-error: true

--- a/.github/workflows/comment_pr.yml
+++ b/.github/workflows/comment_pr.yml
@@ -1,0 +1,58 @@
+name: Comment on the pull request
+
+# read-write repo token
+# access to secrets
+on:
+  workflow_run:
+    workflows: [ "Static analysis", "Testing ArkScript" ]
+    types:
+      - completed
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  elevated:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: 'Download artifact'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pr
+          path: ${{ runner.temp }}/pr # do not extract in the workspace dir that may contain executable scripts
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract PR data
+        run: |
+          echo "NR<<EOF" >> $GITHUB_ENV
+          cat "${{ runner.temp }}/pr/NR" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+          echo "COMMENT<<EOF" >> $GITHUB_ENV
+          cat "${{ runner.temp }}/pr/comment" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+          echo "SLUG<<EOF" >> $GITHUB_ENV
+          cat "${{ runner.temp }}/pr/slug" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@fec22f13a3d7a949297e4b5f6b9f99a423eabba1 # v3.1.0
+        id: fc
+        with:
+          issue-number: ${{ env.NR }}
+          comment-author: 'github-actions[bot]'
+          body-includes: ${{ env.SLUG }}
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@cf911f109bd9a26f1d626a8c3276384ddec0e552 # v4.0.0
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: ${{ env.COMMENT }}
+          edit-mode: replace

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 permissions:
-  pull-requests: write  # Required for commenting on pull requests
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -49,24 +49,18 @@ jobs:
           echo "$content" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
-      - name: Find Comment
-        uses: peter-evans/find-comment@fec22f13a3d7a949297e4b5f6b9f99a423eabba1 # v3.1.0
-        id: fc
+      - name: Save PR identifiers
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+          echo "Static analysis report" > ./pr/slug
+
+          echo "## Static analysis report" > ./pr/comment
+          echo "${{ env.LIZARD_REPORT }}" >> ./pr/comment
+          echo -e "\n---\n" >> ./pr/comment
+          echo "${{ env.CPPCHECK_REPORT }}" >> ./pr/comment
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: Static analysis report
-
-      - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@cf911f109bd9a26f1d626a8c3276384ddec0e552 # v4.0.0
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            ## Static analysis report
-            ${{ env.LIZARD_REPORT }}
-
-            ---
-
-            ${{ env.CPPCHECK_REPORT }}
-          edit-mode: replace
+          name: pr
+          path: pr/


### PR DESCRIPTION
## Description

Use a dedicated workflow to create/update automated PR comments, so that external contributors do not get a 403 when Fuzz testing / Static analysis jobs are running.

## Checklist

- [x] I have read the [Contributor guide](https://arkscript-lang.dev/docs/guides/contributing/)
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation if needed (on https://github.com/ArkScript-lang/website, content/docs/)
- [ ] I have added tests that prove my fix/feature is working
- [ ] New and existing tests pass locally with my changes
- [x] I confirm that I am the author of this code and release it to the ArkScript project under the MPL-2.0 license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").
