### PR TITLE
perf: improve fqn lookups in namespaces

### DIFF
--- a/src/arkreactor/Compiler/NameResolution/StaticScope.cpp
+++ b/src/arkreactor/Compiler/NameResolution/StaticScope.cpp
@@ -84,8 +84,21 @@ namespace Ark::internal
         // If the name wasn't qualified, in the current prefixed namespace, look up for it but by qualifying the name
         else if (!starts_with_prefix)
         {
-            const auto it = std::ranges::find(m_vars, fullyQualifiedName(name), &Declaration::name);
-            const auto it_original = std::ranges::find(m_vars, fullyQualifiedName(name), &Declaration::original_name);
+            const auto fqn = fullyQualifiedName(name);
+
+            auto it = m_vars.end();
+            auto it_original = m_vars.end();
+            for (auto j = m_vars.begin(), end = m_vars.end(); j != end; ++j)
+            {
+                if (j->name == fqn)
+                    it = j;
+                if (j->original_name == fqn)
+                    it_original = j;
+
+                if (it != end && it_original != end)
+                    break;
+            }
+
             if ((m_is_glob || hasSymbol(name) || (m_with_prefix && origin_namespace == m_namespace)) && it != m_vars.end())
                 return *it;
             if (!m_symbols.empty() && it_original != m_vars.end())
@@ -100,7 +113,7 @@ namespace Ark::internal
                 if (auto maybe_decl = scope->get(name, origin_namespace, extensive_lookup); maybe_decl.has_value())
                 {
                     // prioritize non-hidden declarations
-                    if ((decl.has_value() && decl.value().name.ends_with(HiddenSymbolSuffix)) || !decl.has_value())
+                    if ((decl.has_value() && decl->name.ends_with(HiddenSymbolSuffix)) || !decl.has_value())
                         decl = maybe_decl;
                 }
             }


### PR DESCRIPTION
## Description

Improve fully qualified names lookups in namespaces.

In debug mode, this improves the name resolution by about 40%.

## Checklist

- [x] I have read the [Contributor guide](https://arkscript-lang.dev/docs/guides/contributing/)
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation if needed (on https://github.com/ArkScript-lang/website, content/docs/)
- [ ] I have added tests that prove my fix/feature is working
- [x] New and existing tests pass locally with my changes
- [x] I confirm that I am the author of this code and release it to the ArkScript project under the MPL-2.0 license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").
