### PR TITLE
docs: fix the broken star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Huge thanks to those people for their donations to support the project:
 
 ## Cool graphs
 
-[![Star History Chart](https://api.star-history.com/svg?repos=arkscript-lang/ark&type=Date)](https://star-history.com/#arkscript-lang/ark&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=arkscript-lang/ark&type=Date)](https://star-history.dera.page/#arkscript-lang/ark&Date)
 
 ## Credits
 


### PR DESCRIPTION
The Star History chart in the README is currently broken because of changes to the GitHub stargazer API that the previous provider relied on. This switches the chart to star-history.dera.page, which uses an alternative data source that requires no API token, restoring the graph.